### PR TITLE
Add caching to `toArray` method

### DIFF
--- a/src/MyCLabs/Enum/Enum.php
+++ b/src/MyCLabs/Enum/Enum.php
@@ -65,7 +65,7 @@ abstract class Enum
     {
         $calledClass = get_called_class();
         if(!array_key_exists($calledClass, self::$constantsCache)) {
-            $reflectin = new \ReflectionClass($calledClass);
+            $reflection = new \ReflectionClass($calledClass);
             self::$constantsCache[$calledClass] = $reflection->getConstants();
         }
         return self::$constantsCache[$calledClass];


### PR DESCRIPTION
Reflection can be slow on occasions and this optimization should be beneficial if `toArray` is being called more than once per request.
