### PR TITLE
Added new methods and changed source structure to be PSR4 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install
+  - composer self-update
+  - composer install --no-interaction --dev
 
-script: phpunit --configuration phpunit.xml tests
+script:
+  - vendor/bin/phpunit
+  - vendor/bin/phpcs --standard=PSR2 ./src/

--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ function setAction(Action $action) {
 - `__construct()` The constructor checks that the value exist in the enum
 - `__toString()` You can `echo $myValue`, it will display the enum value (value of the constant)
 - `getValue()` Returns the current value of the enum
-- `toArray()` (static) Returns an array of all possible values (constant name in key, constant value in value)
+- `getKey()` Returns the key of the current value on Enum
+- `keys()` (@static) Returns the names (keys) of all constants in the Enum class
+- `values()` (@static) method Returns all possible values as an array (constant name in key, constant value in value)
+- `toArray()` (@static and @deprecated) Alias for `values()`
+- `isValid()` (@static) Check if tested value is valid on enum set
+- `isValidKey()` (@static) Check if tested key is valid on enum set
+- `search()` Return key for searched value
 
 ### Static methods
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ function setAction(Action $action) {
 - `getValue()` Returns the current value of the enum
 - `getKey()` Returns the key of the current value on Enum
 - `keys()` (@static) Returns the names (keys) of all constants in the Enum class
-- `values()` (@static) method Returns all possible values as an array (constant name in key, constant value in value)
-- `toArray()` (@static and @deprecated) Alias for `values()`
+- `toArray()` (@static) method Returns all possible values as an array (constant name in key, constant value in value)
 - `isValid()` (@static) Check if tested value is valid on enum set
 - `isValidKey()` (@static) Check if tested key is valid on enum set
 - `search()` Return key for searched value

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,22 @@
     "keywords": ["enum"],
     "homepage": "http://github.com/myclabs/php-enum",
     "license": "MIT",
+    "authors": [
+        {
+            "name": "PHP Enum contributors",
+            "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+        }
+    ],
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "MyCLabs\\Enum\\": "src/"
         }
+    },
+    "require": {
+        "php": ">=5.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "4.*",
+        "squizlabs/php_codesniffer": "1.*"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,11 +12,9 @@
          stopOnFailure="false"
          syntaxCheck="false"
          bootstrap="./vendor/autoload.php">
-
     <testsuites>
-        <testsuite name="Enum Test Suite">
-            <directory>./tests</directory>
+        <testsuite name="PHP Enum Test Suite">
+            <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
-
 </phpunit>

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -39,7 +39,7 @@ abstract class Enum
      */
     public function __construct($value)
     {
-        if (!in_array($value, self::values())) {
+        if (!in_array($value, self::toArray())) {
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . get_called_class());
         }
 
@@ -79,7 +79,7 @@ abstract class Enum
      */
     public static function keys()
     {
-        return array_keys(static::values());
+        return array_keys(static::toArray());
     }
 
     /**
@@ -87,7 +87,7 @@ abstract class Enum
      *
      * @return array Constant name in key, constant value in value
      */
-    public static function values()
+    public static function toArray()
     {
         $class = get_called_class();
         if (!array_key_exists($class, self::$cache)) {
@@ -96,17 +96,6 @@ abstract class Enum
         }
 
         return self::$cache[$class];
-    }
-
-    /**
-     * An alias method for values()
-     *
-     * @return array
-     * @deprecated
-     */
-    public static function toArray()
-    {
-        return self::values();
     }
 
     /**
@@ -120,7 +109,7 @@ abstract class Enum
      */
     public static function isValid($value)
     {
-        return in_array($value, self::values());
+        return in_array($value, self::toArray());
     }
 
     /**
@@ -148,7 +137,7 @@ abstract class Enum
      */
     public static function search($value)
     {
-        return array_search($value, array_combine(self::keys(), self::values()));
+        return array_search($value, array_combine(self::keys(), self::toArray()));
     }
 
     /**

--- a/tests/EnumFixture.php
+++ b/tests/EnumFixture.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @link    http://github.com/myclabs/php-enum
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace MyCLabs\Enum;
+
+/**
+ * Class EnumFixture
+ *
+ * @package MyCLabs\Enum
+ * @method static EnumFixture FOO()
+ * @method static EnumFixture BAR()
+ * @method static EnumFixture NUMBER()
+ * @author Daniel Costa <danielcosta@gmail.com
+ */
+class EnumFixture extends Enum
+{
+    const FOO = "foo";
+    const BAR = "bar";
+    const NUMBER = 42;
+}

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -94,11 +94,11 @@ class EnumTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * values()
+     * toArray()
      */
-    public function testValues()
+    public function testToArray()
     {
-        $values = EnumFixture::values();
+        $values = EnumFixture::toArray();
         $this->assertInternalType("array", $values);
         $expectedValues = array(
             "FOO"    => EnumFixture::FOO,
@@ -106,14 +106,6 @@ class EnumTest extends \PHPUnit_Framework_TestCase
             "NUMBER" => EnumFixture::NUMBER,
         );
         $this->assertEquals($expectedValues, $values);
-    }
-
-    /**
-     * toArray()
-     */
-    public function testToArray()
-    {
-        $this->assertEquals(EnumFixture::values(), EnumFixture::toArray());
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -4,13 +4,12 @@
  * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
  */
 
-namespace UnitTest\MyCLabs\Enum\Enum;
-
-use MyCLabs\Enum\Enum;
+namespace MyCLabs\Enum;
 
 /**
  * Enum test
  *
+ * @package MyCLabs\Enum
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
 class EnumTest extends \PHPUnit_Framework_TestCase
@@ -31,9 +30,19 @@ class EnumTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * getKey()
+     */
+    public function testGetKey()
+    {
+        $value = new EnumFixture(EnumFixture::FOO);
+        $this->assertEquals('FOO', $value->getKey());
+        $this->assertNotEquals('BA', $value->getKey());
+    }
+
+    /**
      * @expectedException \UnexpectedValueException
      */
-    public function testInvalidValue1()
+    public function testInvalidValueString()
     {
         new EnumFixture("test");
     }
@@ -41,7 +50,7 @@ class EnumTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \UnexpectedValueException
      */
-    public function testInvalidValue2()
+    public function testInvalidValueInt()
     {
         new EnumFixture(1234);
     }
@@ -49,7 +58,7 @@ class EnumTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \UnexpectedValueException
      */
-    public function testInvalidValue3()
+    public function testInvalidValueEmpty()
     {
         new EnumFixture(null);
     }
@@ -70,11 +79,26 @@ class EnumTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * toArray()
+     * keys()
      */
-    public function testToArray()
+    public function testKeys()
     {
-        $values = EnumFixture::toArray();
+        $values = EnumFixture::keys();
+        $this->assertInternalType("array", $values);
+        $expectedValues = array(
+            "FOO",
+            "BAR",
+            "NUMBER",
+        );
+        $this->assertEquals($expectedValues, $values);
+    }
+
+    /**
+     * values()
+     */
+    public function testValues()
+    {
+        $values = EnumFixture::values();
         $this->assertInternalType("array", $values);
         $expectedValues = array(
             "FOO"    => EnumFixture::FOO,
@@ -82,6 +106,14 @@ class EnumTest extends \PHPUnit_Framework_TestCase
             "NUMBER" => EnumFixture::NUMBER,
         );
         $this->assertEquals($expectedValues, $values);
+    }
+
+    /**
+     * toArray()
+     */
+    public function testToArray()
+    {
+        $this->assertEquals(EnumFixture::values(), EnumFixture::toArray());
     }
 
     /**
@@ -96,24 +128,38 @@ class EnumTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage No static method or enum constant 'UNKNOWN' in class UnitTest\MyCLabs\Enum\Enum\EnumFixture
+     * @expectedExceptionMessage No static method or enum constant 'UNKNOWN' in class
+     *                           UnitTest\MyCLabs\Enum\Enum\EnumFixture
      */
     public function testBadStaticAccess()
     {
         EnumFixture::UNKNOWN();
     }
-}
 
-/**
- * Fixture class
- *
- * @method static EnumFixture FOO()
- * @method static EnumFixture BAR()
- * @method static EnumFixture NUMBER()
- */
-class EnumFixture extends Enum
-{
-    const FOO = "foo";
-    const BAR = "bar";
-    const NUMBER = 42;
+    /**
+     * isValid()
+     */
+    public function testIsValid()
+    {
+        $this->assertTrue(EnumFixture::isValid('foo'));
+        $this->assertFalse(EnumFixture::isValid('baz'));
+    }
+
+    /**
+     * ssValidKey()
+     */
+    public function testIsValidKey()
+    {
+        $this->assertTrue(EnumFixture::isValidKey('FOO'));
+        $this->assertFalse(EnumFixture::isValidKey('BAZ'));
+    }
+
+    /**
+     * search()
+     */
+    public function testSearch()
+    {
+        $this->assertEquals('FOO', EnumFixture::search('foo'));
+        $this->assertNotEquals('FOO', EnumFixture::isValidKey('baz'));
+    }
 }


### PR DESCRIPTION
- PSR4 compatible package
- new getKey() method (returns the key of the current value on Enum)
- new keys() method (returns the names (keys) of all constants in the Enum class)
- moved toArray() to values() method (returns all possible values as an array)
- flagged toArray() as deprecated for future removal
- new isValid() static method (check if tested value is valid on enum set)
- new isValidKey() static method (check if tested key is valid on enum set)
- new search() method (return key for searched value)