### PR TITLE
Change calls to method toArray() from self::toArray() to static::toArray()

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -70,7 +70,7 @@ abstract class Enum
      */
     public function __toString()
     {
-        return (string) $this->value;
+        return (string)$this->value;
     }
 
     /**
@@ -108,7 +108,7 @@ abstract class Enum
     {
         $class = get_called_class();
         if (!array_key_exists($class, self::$cache)) {
-            $reflection = new \ReflectionClass($class);
+            $reflection          = new \ReflectionClass($class);
             self::$cache[$class] = $reflection->getConstants();
         }
 
@@ -119,6 +119,7 @@ abstract class Enum
      * Check if is valid enum value
      *
      * @param $value
+     *
      * @return bool
      */
     public static function isValid($value)
@@ -136,6 +137,7 @@ abstract class Enum
     public static function isValidKey($key)
     {
         $array = static::toArray();
+
         return isset($array[$key]);
     }
 
@@ -162,8 +164,10 @@ abstract class Enum
      */
     public static function __callStatic($name, $arguments)
     {
-        if (defined("static::$name")) {
-            return new static(constant("static::$name"));
+        if (static::isValidKey($name)) {
+            $array = static::toArray();
+
+            return new static($array[$name]);
         }
 
         throw new \BadMethodCallException("No static method or enum constant '$name' in class " . get_called_class());

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -80,7 +80,7 @@ abstract class Enum
      */
     public static function keys()
     {
-        return array_keys(self::toArray());
+        return array_keys(static::toArray());
     }
 
     /**
@@ -92,7 +92,7 @@ abstract class Enum
     {
         $values = array();
 
-        foreach (self::toArray() as $key => $value) {
+        foreach (static::toArray() as $key => $value) {
             $values[$key] = new static($value);
         }
 
@@ -123,7 +123,7 @@ abstract class Enum
      */
     public static function isValid($value)
     {
-        return in_array($value, self::toArray(), true);
+        return in_array($value, static::toArray(), true);
     }
 
     /**
@@ -135,7 +135,7 @@ abstract class Enum
      */
     public static function isValidKey($key)
     {
-        $array = self::toArray();
+        $array = static::toArray();
         return isset($array[$key]);
     }
 
@@ -148,7 +148,7 @@ abstract class Enum
      */
     public static function search($value)
     {
-        return array_search($value, self::toArray(), true);
+        return array_search($value, static::toArray(), true);
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -108,7 +108,7 @@ abstract class Enum
     {
         $class = get_called_class();
         if (!array_key_exists($class, static::$cache)) {
-            $reflection          = new \ReflectionClass($class);
+            $reflection            = new \ReflectionClass($class);
             static::$cache[$class] = $reflection->getConstants();
         }
 
@@ -164,9 +164,8 @@ abstract class Enum
      */
     public static function __callStatic($name, $arguments)
     {
-        if (static::isValidKey($name)) {
-            $array = static::toArray();
-
+        $array = static::toArray();
+        if (isset($array[$name])) {
             return new static($array[$name]);
         }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -29,7 +29,7 @@ abstract class Enum
      *
      * @var array
      */
-    private static $cache = array();
+    protected static $cache = array();
 
     /**
      * Creates a new value of some type
@@ -62,7 +62,7 @@ abstract class Enum
      */
     public function getKey()
     {
-        return self::search($this->value);
+        return static::search($this->value);
     }
 
     /**
@@ -107,12 +107,12 @@ abstract class Enum
     public static function toArray()
     {
         $class = get_called_class();
-        if (!array_key_exists($class, self::$cache)) {
+        if (!array_key_exists($class, static::$cache)) {
             $reflection          = new \ReflectionClass($class);
-            self::$cache[$class] = $reflection->getConstants();
+            static::$cache[$class] = $reflection->getConstants();
         }
 
-        return self::$cache[$class];
+        return static::$cache[$class];
     }
 
     /**


### PR DESCRIPTION
See #20 
The idea is to allow subclasses to provide a data set different from constants list. The default implementation still use constants but you can extend it to use different data source; so for instance if you have data stored in a DB you can still use your specific Enum in type hinting, but fetch data from DB.