### PR TITLE
Correct json serialization of Enum object instead of just {}

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -80,7 +80,7 @@ abstract class Enum implements \JsonSerializable
      * @return mixed data which can be serialized by <b>json_encode</b>,
      * which is a value of any type other than a resource.
      */
-    function jsonSerialize()
+    public function jsonSerialize()
     {
         return $this->getValue();
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -82,7 +82,7 @@ abstract class Enum implements \JsonSerializable
      */
     function jsonSerialize()
     {
-        return $this->value;
+        return $this->getValue();
     }
 
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -15,7 +15,7 @@ namespace MyCLabs\Enum;
  * @author Daniel Costa <danielcosta@gmail.com>
  * @author Mirosław Filip <mirfilip@gmail.com>
  */
-abstract class Enum
+abstract class Enum implements \JsonSerializable
 {
     /**
      * Enum value
@@ -72,6 +72,19 @@ abstract class Enum
     {
         return (string)$this->value;
     }
+
+    /**
+     * (PHP 5 &gt;= 5.4.0)<br/>
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     */
+    function jsonSerialize()
+    {
+        return $this->value;
+    }
+
 
     /**
      * Returns the names (keys) of all constants in the Enum class

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -71,6 +71,21 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, (string) $enumObject);
     }
 
+    public function testJsonEncode()
+    {
+        $value = new EnumFixture(EnumFixture::FOO);
+        $encoded = json_encode($value);
+        $this->assertEquals($encoded, '"'.EnumFixture::FOO.'"');
+
+        $value = new EnumFixture(EnumFixture::BAR);
+        $encoded = json_encode($value);
+        $this->assertEquals($encoded, '"'.EnumFixture::BAR.'"');
+
+        $value = new EnumFixture(EnumFixture::NUMBER);
+        $encoded = json_encode($value);
+        $this->assertEquals($encoded, EnumFixture::NUMBER);
+    }
+
     public function toStringProvider() {
         return array(
             array(EnumFixture::FOO, new EnumFixture(EnumFixture::FOO)),


### PR DESCRIPTION
JsonSerializable was added only in PHP 5.4, but that's highly useful change