### PR TITLE
Declare equals() as final

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ function setAction(Action $action) {
 - `__toString()` You can `echo $myValue`, it will display the enum value (value of the constant)
 - `getValue()` Returns the current value of the enum
 - `getKey()` Returns the key of the current value on Enum
+- `equals()` Tests whether enum instances are equal (returns `true` if enum values are equal, `false` otherwise)
 
 Static methods:
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -78,7 +78,7 @@ abstract class Enum
      *
      * @return bool True if Enums are equal, false if not equal
      */
-    public function equals(Enum $enum)
+    final public function equals(Enum $enum)
     {
         return $this->getValue() === $enum->getValue();
     }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -214,12 +214,17 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * equals()
+     */
     public function testEquals()
     {
-        $enum = new EnumFixture(EnumFixture::FOO);
-        $this->assertTrue($enum->equals(EnumFixture::FOO()));
+        $foo = new EnumFixture(EnumFixture::FOO);
+        $number = new EnumFixture(EnumFixture::NUMBER);
+        $anotherFoo = new EnumFixture(EnumFixture::FOO);
 
-        $enum = new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE);
-        $this->assertFalse($enum->equals(EnumFixture::PROBLEMATIC_EMPTY_STRING()));
+        $this->assertTrue($foo->equals($foo));
+        $this->assertFalse($foo->equals($number));
+        $this->assertTrue($foo->equals($anotherFoo));
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -227,4 +227,19 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($foo->equals($number));
         $this->assertTrue($foo->equals($anotherFoo));
     }
+
+    /**
+     * equals()
+     */
+    public function testEqualsComparesProblematicValuesProperly()
+    {
+        $false = new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE);
+        $emptyString = new EnumFixture(EnumFixture::PROBLEMATIC_EMPTY_STRING);
+        $null = new EnumFixture(EnumFixture::PROBLEMATIC_NULL);
+
+        $this->assertTrue($false->equals($false));
+        $this->assertFalse($false->equals($emptyString));
+        $this->assertFalse($emptyString->equals($null));
+        $this->assertFalse($null->equals($false));
+    }
 }


### PR DESCRIPTION
Addresses suggestions from conversation in #4.

- Adds `final` to `equals()`
- Update tests per suggestions from @mirfilip
    - Rewrite original tests
    - Add tests proving `equals()` handles problematic values properly
- Add `equals()` to documentation