### PR TITLE
Add missing annotation

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -78,6 +78,8 @@ abstract class Enum
      *
      * This method is final, for more information read https://github.com/myclabs/php-enum/issues/4
      *
+     * @param Enum $enum
+     *
      * @return bool True if Enums are equal, false if not equal
      */
     final public function equals(Enum $enum)


### PR DESCRIPTION
The method `equals` is missing an annotation for it's `$enum` parameter.