### PR TITLE
Add implode() method for convenience

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -128,6 +128,18 @@ abstract class Enum
     }
 
     /**
+     * Concatenate all possible values as a string
+     *
+     * @param string $glue
+     *
+     * @return string
+     */
+    public static function implode($glue)
+    {
+        return implode($glue, static::toArray());
+    }
+
+    /**
      * Check if is valid enum value
      *
      * @param $value

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -142,7 +142,7 @@ class EnumTest extends \PHPUnit_Framework_TestCase
     public function testImplode()
     {
         $value = EnumFixture::implode(',');
-        $expectedValue = implode(',', [
+        $expectedValue = implode(',', array(
             EnumFixture::FOO,
             EnumFixture::BAR,
             EnumFixture::NUMBER,
@@ -150,7 +150,7 @@ class EnumTest extends \PHPUnit_Framework_TestCase
             EnumFixture::PROBLEMATIC_NULL,
             EnumFixture::PROBLEMATIC_EMPTY_STRING,
             EnumFixture::PROBLEMATIC_BOOLEAN_FALSE,
-        ]);
+        ));
 
         $this->assertSame($expectedValue, $value);
     }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -137,6 +137,25 @@ class EnumTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * implode()
+     */
+    public function testImplode()
+    {
+        $value = EnumFixture::implode(',');
+        $expectedValue = implode(',', [
+            EnumFixture::FOO,
+            EnumFixture::BAR,
+            EnumFixture::NUMBER,
+            EnumFixture::PROBLEMATIC_NUMBER,
+            EnumFixture::PROBLEMATIC_NULL,
+            EnumFixture::PROBLEMATIC_EMPTY_STRING,
+            EnumFixture::PROBLEMATIC_BOOLEAN_FALSE,
+        ]);
+
+        $this->assertSame($expectedValue, $value);
+    }
+
+    /**
      * __callStatic()
      */
     public function testStaticAccess()


### PR DESCRIPTION
I extend your class in most of my Laravel projects to add this method. It's especially useful for "in" validation rules.