### PR TITLE
Use modern phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,12 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - nightly
   - hhvm
+
+matrix:
+    allow_failures:
+        - php: hhvm
 
 before_script:
   - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*",
+        "phpunit/phpunit": "^4.8.35|^5.7|^6.0",
         "squizlabs/php_codesniffer": "1.*"
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -11,7 +11,7 @@ namespace MyCLabs\Tests\Enum;
  * @author Daniel Costa <danielcosta@gmail.com>
  * @author Mirosław Filip <mirfilip@gmail.com>
  */
-class EnumTest extends \PHPUnit_Framework_TestCase
+class EnumTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * getValue()
@@ -40,14 +40,11 @@ class EnumTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider invalidValueProvider
+     * @expectedException UnexpectedValueException
+     * @expectedExceptionMessage is not part of the enum MyCLabs\Tests\Enum\EnumFixture
      */
     public function testCreatingEnumWithInvalidValue($value)
     {
-        $this->setExpectedException(
-            '\UnexpectedValueException',
-            'Value \'' . $value . '\' is not part of the enum MyCLabs\Tests\Enum\EnumFixture'
-        );
-
         new EnumFixture($value);
     }
 


### PR DESCRIPTION
Allow  4.8.35, 5.7, 6.0 which all have the forward compatibility layer

So
* 4.8 will be used with old PHP version (<5.6)
* 5.7 will be used with PHP 5.6
* 6.0 will be used with PHP 7+

7.2 enabled in travis.