### PR TITLE
Add description and code annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ function setAction(Action $action) {
 - `__toString()` You can `echo $myValue`, it will display the enum value (value of the constant)
 - `getValue()` Returns the current value of the enum
 - `getKey()` Returns the key of the current value on Enum
+- `getDescription()` Returns content of description annotation or BadMethodCallException if not set
+- `getCode()` Returns content of code annotation or BadMethodCallException if not set
 - `equals()` Tests whether enum instances are equal (returns `true` if enum values are equal, `false` otherwise)
 
 Static methods:

--- a/src/ConstAnnotationsParser.php
+++ b/src/ConstAnnotationsParser.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace MyCLabs\Enum;
+
+/**
+ * Parse and return annotations for php class const
+ *
+ * Class ConstAnnotationsParser
+ * @package MyCLabs\Enum
+ */
+abstract class ConstAnnotationsParser
+{
+    /**
+     * Parses the class for constant annotations
+     *
+     * @param $class
+     * @return mixed
+     */
+    public static function parseAndReturnAnnotations($class)
+    {
+        $constantsAnnotations = array();
+        $class = new \ReflectionClass($class);
+        $content = file_get_contents($class->getFileName());
+        $tokens = token_get_all($content);
+        $doc = null;
+        $isConst = false;
+        foreach($tokens as $token)
+        {
+            if (count($token) <= 1)
+            {
+                continue;
+            }
+
+            list($tokenType, $tokenValue) = $token;
+
+            switch ($tokenType)
+            {
+                // ignored tokens
+                case T_WHITESPACE:
+                case T_COMMENT:
+                    break;
+
+                case T_DOC_COMMENT:
+                    $doc = $tokenValue;
+                    break;
+
+                case T_CONST:
+                    $isConst = true;
+                    break;
+
+                case T_STRING:
+                    if ($isConst)
+                    {
+                        $annotations = array();
+                        $lines = preg_split('/\R/', $doc);
+                        foreach($lines as $line)
+                        {
+                            $line = trim($line, "/* \t\x0B\0");
+                            if ($line === '')
+                            {
+                                continue;
+                            }
+                            preg_match_all("/@(\w+)\(\s*([^\(]*?)\s*\)/",$line, $match);
+                            if(count($match) > 0) {
+                                for($i = 0; $i < count($match[0]); $i++){
+                                    $annotations[$match[1][$i]] = trim($match[2][$i], "'\"");
+                                }
+                            }
+                        }
+                        $constantsAnnotations[$tokenValue] = $annotations;
+                    }
+                    $doc = null;
+                    $isConst = false;
+                    break;
+
+                // all other tokens reset the parser
+                default:
+                    $doc = null;
+                    $isConst = false;
+                    break;
+            }
+        }
+        return $constantsAnnotations;
+    }
+}

--- a/tests/EnumFixture.php
+++ b/tests/EnumFixture.php
@@ -25,7 +25,15 @@ use MyCLabs\Enum\Enum;
  */
 class EnumFixture extends Enum
 {
+    /**
+     * @description('Foo description')
+     * @code("Foo code")
+     */
     const FOO = "foo";
+    /**
+     * @Description('Bar Description')
+     * @Code('Bar Code')
+     */
     const BAR = "bar";
     const NUMBER = 42;
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -247,4 +247,34 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertFalse(EnumFixture::FOO()->equals(EnumConflict::FOO()));
     }
+
+    /**
+     * getDescription method
+     */
+    public function testGetDescription()
+    {
+        $fooDescription = EnumFixture::FOO();
+        $barDescription = new EnumFixture(EnumFixture::BAR);
+        $wrongNumberDescription = EnumFixture::NUMBER();
+
+        $this->assertTrue($fooDescription->getDescription() === 'Foo description');
+        $this->assertTrue($barDescription->getDescription() === 'Bar Description');
+        $this->expectException(\BadMethodCallException::class);
+        $wrongNumberDescription->getDescription();
+    }
+
+    /**
+     * getCode method
+     */
+    public function testGetCode()
+    {
+        $fooCode = EnumFixture::FOO();
+        $barCode = new EnumFixture(EnumFixture::BAR);
+        $wrongNumberCode = EnumFixture::NUMBER();
+
+        $this->assertTrue($fooCode->getCode() === 'Foo code');
+        $this->assertTrue($barCode->getCode() == 'Bar Code');
+        $this->expectException(\BadMethodCallException::class);
+        $wrongNumberCode->getCode();
+    }
 }


### PR DESCRIPTION
Add possibility to add description and code annotation. So you can use only int type for enum value and add string on description or code annotations for example use directly on view the string description related of int value :
Enum::Value()->getDescription = 'Value description'