### PR TITLE
Add support for json_encode

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -189,7 +189,8 @@ abstract class Enum implements \JsonSerializable
      *
      * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize()
+    {
         return $this->value;
     }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -15,7 +15,7 @@ namespace MyCLabs\Enum;
  * @author Daniel Costa <danielcosta@gmail.com>
  * @author Mirosław Filip <mirfilip@gmail.com>
  */
-abstract class Enum
+abstract class Enum implements \JsonSerializable
 {
     /**
      * Enum value
@@ -182,5 +182,14 @@ abstract class Enum
         }
 
         throw new \BadMethodCallException("No static method or enum constant '$name' in class " . get_called_class());
+    }
+
+    /**
+     * Return the value when serialized with json_encode
+     *
+     * @return mixed
+     */
+    public function jsonSerialize() {
+        return $this->value;
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -247,4 +247,21 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertFalse(EnumFixture::FOO()->equals(EnumConflict::FOO()));
     }
+
+    /**
+     * json_encode normally returns the Enum object itself,
+     * but it should return the value of the enum instead
+     */
+    public function testJsonEncode()
+    {
+        $foo = new EnumFixture(EnumFixture::FOO);
+
+        $object = (object)[
+            'myFoo' => $foo
+        ];
+
+        $json = json_encode($object);
+
+        $this->assertEquals($json, '{"myFoo":"foo"}');
+    }
 }


### PR DESCRIPTION
When using json_encode on an enum currently returns the object. `"{}"`, but it should return the value.