### PR TITLE
Add search by key feature

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -166,6 +166,27 @@ abstract class Enum
     }
 
     /**
+     * Create a new value of the Enum class by the key of the constants.
+     *
+     * @param string $key
+     *
+     * @return static
+     * @throws \UnexpectedValueException if incompatible key is given.
+     */
+    public static function key($key)
+    {
+        $class = get_called_class();
+        try {
+            $reflection = new \ReflectionClass($class);
+            $value      = $reflection->getConstant($key);
+
+            return new static($value);
+        } catch (\ReflectionException $e) {
+            throw new \UnexpectedValueException("Key '$key' is not part of the enum " . $class);
+        }
+    }
+
+    /**
      * Returns a value when called statically like so: MyEnum::SOME_VALUE() given SOME_VALUE is a class constant
      *
      * @param string $name

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -247,4 +247,15 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertFalse(EnumFixture::FOO()->equals(EnumConflict::FOO()));
     }
+
+    /**
+     * equals()
+     */
+    public function testByKey()
+    {
+        $expected = new EnumFixture(EnumFixture::FOO);
+        $false = new EnumFixture(EnumFixture::BAR);
+        $this->assertTrue($expected->equals(EnumFixture::key("FOO")));
+        $this->assertFalse($false->equals(EnumFixture::key("FOO")));
+    }
 }


### PR DESCRIPTION
In my professional company we have the following use case : 
Our front-end send us key constant (because it's more easy to manipulate) (let's say FOO) and we need to get an Enum instance by this key but not by value.

The following enum could look like this :
```php
<?php

namespace MyNamespace;

use MyCLabs\Enum\Enum;

class MyEnum extends Enum {
   const FOO = 1;
}
```

Thanks to this PR we can have an instance of Enum by key.
If you have any comment please be my guest.