### PR TITLE
Drop support for PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
   - hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.7|^6.0",


### PR DESCRIPTION
As discussed in issue #67 this PR drops support for PHP 5.3 as preparation for the implementation of the `JsonSerializable` interface.

This change probably requires a new major release because it's a backwards incompatible change. However, this release can wait for the next PR because just now there are no new features to release.