### PR TITLE
Implement JsonSerializable, fixes #67

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
   - hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.7|^6.0",

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -15,7 +15,7 @@ namespace MyCLabs\Enum;
  * @author Daniel Costa <danielcosta@gmail.com>
  * @author Mirosław Filip <mirfilip@gmail.com>
  */
-abstract class Enum
+abstract class Enum implements \JsonSerializable
 {
     /**
      * Enum value
@@ -182,5 +182,17 @@ abstract class Enum
         }
 
         throw new \BadMethodCallException("No static method or enum constant '$name' in class " . get_called_class());
+    }
+
+    /**
+     * Specify data which should be serialized to JSON. This method returns data that can be serialized by json_encode()
+     * natively.
+     *
+     * @return mixed
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     */
+    public function jsonSerialize()
+    {
+        return $this->getValue();
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -40,7 +40,7 @@ class EnumTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider invalidValueProvider
-     * @expectedException UnexpectedValueException
+     * @expectedException \UnexpectedValueException
      * @expectedExceptionMessage is not part of the enum MyCLabs\Tests\Enum\EnumFixture
      */
     public function testCreatingEnumWithInvalidValue($value)
@@ -246,5 +246,19 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     public function testEqualsConflictValues()
     {
         $this->assertFalse(EnumFixture::FOO()->equals(EnumConflict::FOO()));
+    }
+
+    /**
+     * jsonSerialize()
+     */
+    public function testJsonSerialize()
+    {
+        $this->assertJsonStringEqualsJsonString('"foo"', json_encode(new EnumFixture(EnumFixture::FOO)));
+        $this->assertJsonStringEqualsJsonString('"bar"', json_encode(new EnumFixture(EnumFixture::BAR)));
+        $this->assertJsonStringEqualsJsonString('42',    json_encode(new EnumFixture(EnumFixture::NUMBER)));
+        $this->assertJsonStringEqualsJsonString('0',     json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_NUMBER)));
+        $this->assertJsonStringEqualsJsonString('null',  json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_NULL)));
+        $this->assertJsonStringEqualsJsonString('""',    json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_EMPTY_STRING)));
+        $this->assertJsonStringEqualsJsonString('false', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE)));
     }
 }


### PR DESCRIPTION
Note that PR #68 should be merged first.

This PR makes `Enum` objects serializable with `json_encode()`, as discussed in #67.