### PR TITLE
Enums can accept multiple arguments.

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -178,7 +178,10 @@ abstract class Enum implements \JsonSerializable
     {
         $array = static::toArray();
         if (isset($array[$name])) {
-            return new static($array[$name]);
+            $self = new \ReflectionClass(static::class);
+            $arguments = array_merge([$array[$name]], $arguments);
+
+            return $self->newInstanceArgs($arguments);
         }
 
         throw new \BadMethodCallException("No static method or enum constant '$name' in class " . get_called_class());

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -178,7 +178,7 @@ abstract class Enum implements \JsonSerializable
     {
         $array = static::toArray();
         if (isset($array[$name])) {
-            $self = new \ReflectionClass(static::class);
+            $self = new \ReflectionClass(get_called_class());
             $arguments = array_merge([$array[$name]], $arguments);
 
             return $self->newInstanceArgs($arguments);

--- a/tests/EnumEnhanced.php
+++ b/tests/EnumEnhanced.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @link    http://github.com/myclabs/php-enum
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+namespace MyCLabs\Tests\Enum;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Class EnumEnhanced
+ *
+ * @method static EnumConflict FOO()
+ * @method static EnumConflict BAR()
+ *
+ * @author Zarko Stankovic <stankovic.zarko@gmail.com>
+ */
+class EnumEnhanced extends Enum
+{
+    const FOO = "foo";
+    const BAR = "bar";
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @param mixed  $value
+     * @param string $description
+     */
+    public function __construct($value, $description)
+    {
+        parent::__construct($value);
+
+        $this->description = $description;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+}

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -249,6 +249,15 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(EnumFixture::FOO()->equals(EnumConflict::FOO()));
     }
 
+    public function testEnumWithMultipleArguments()
+    {
+        $foo = new EnumEnhanced(EnumEnhanced::FOO, 'hello, world!');
+        $this->assertEquals($foo->getDescription(), 'hello, world!');
+
+        $bar = EnumEnhanced::BAR('foo, bar, baz!');
+        $this->assertEquals($bar->getDescription(), 'foo, bar, baz!');
+    }
+
     /**
      * jsonSerialize()
      */


### PR DESCRIPTION
Hello,

This PR fixes the limitation of using `__callStatic` to instantiate "enhanced" enums, e.g. the enums that are full-blown objects, not just an enumeration of (usually) strings. I want to emphasize that this feature currently is possible only if we instantiate objects with the `new` keyword. The reason why we can't use `__callStatic` with enums that expect multiple arguments, is because `$arguments` array was ignored, and not passed to the enum' constructor.

To sum up:
- Prior to this PR it was only possible to:

```php
$enum = new MyEnum(MyEnum::FOO, 'some value', 'some other value');
```

While now we can also achieve the same with static calls:

```php
$enum = MyEnum::FOO('some value', 'some other value');
```

This behavior is not something new and is very used in other languages like Java. I would personally expect to not limit ourselves to the enumeration of a single data type, but instead to allow an enumeration of objects:

- https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html
- https://stackoverflow.com/questions/19600684/java-enum-with-multiple-value-types

I really like this library and want to thank you for sharing it with the community!

P.S. Unfortunately the current implementation with reflection really sucks because PHP requirement for this library doesn't allow us to use "splat operator" which became available from PHP 5.6. With splat operator the change would be trivial to just `...$arguments`.