### PR TITLE
Make a PHP 7.1 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - nightly

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         }
     },
     "require": {
-        "php": ">=5.4"
+        "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.7|^6.0",
+        "phpunit/phpunit": "^7.2",
         "squizlabs/php_codesniffer": "1.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.2",
-        "squizlabs/php_codesniffer": "1.*"
+        "squizlabs/php_codesniffer": "^3.3"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./vendor/autoload.php">
     <testsuites>
         <testsuite name="PHP Enum Test Suite">

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -50,6 +50,8 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * Returns the enum value (i.e. the constant value).
+     *
      * @return mixed
      */
     public function getValue()
@@ -130,7 +132,7 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
-     * Check if is valid enum value
+     * Takes a possible enum value and checks if that value would result in a valid enum
      *
      * @param mixed $value
      *
@@ -142,7 +144,7 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
-     * Check if is valid enum key
+     * Takes a possible enum key (i.e. constant name) and checks if it's valid
      *
      * @param mixed $key
      *

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -86,7 +86,7 @@ abstract class Enum implements \JsonSerializable
      */
     final public function equals(Enum $enum = null): bool
     {
-        return $enum !== null && $this->getValue() === $enum->getValue() && static::class === get_class($enum);
+        return $enum !== null && $this->getValue() === $enum->getValue() && static::class === \get_class($enum);
     }
 
     /**
@@ -96,7 +96,7 @@ abstract class Enum implements \JsonSerializable
      */
     public static function keys(): array
     {
-        return array_keys(static::toArray());
+        return \array_keys(static::toArray());
     }
 
     /**
@@ -123,7 +123,7 @@ abstract class Enum implements \JsonSerializable
     public static function toArray(): array
     {
         $class = static::class;
-        if (!array_key_exists($class, static::$cache)) {
+        if (!\array_key_exists($class, static::$cache)) {
             $reflection            = new \ReflectionClass($class);
             static::$cache[$class] = $reflection->getConstants();
         }
@@ -140,7 +140,7 @@ abstract class Enum implements \JsonSerializable
      */
     public static function isValid($value): bool
     {
-        return in_array($value, static::toArray(), true);
+        return \in_array($value, static::toArray(), true);
     }
 
     /**
@@ -166,7 +166,7 @@ abstract class Enum implements \JsonSerializable
      */
     public static function search($value)
     {
-        return array_search($value, static::toArray(), true);
+        return \array_search($value, static::toArray(), true);
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -62,9 +62,9 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns the enum key (i.e. the constant name).
      *
-     * @return mixed
+     * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return static::search($this->value);
     }
@@ -146,11 +146,11 @@ abstract class Enum implements \JsonSerializable
     /**
      * Takes a possible enum key (i.e. constant name) and checks if it's valid
      *
-     * @param mixed $key
+     * @param string $key
      *
      * @return bool
      */
-    public static function isValidKey($key): bool
+    public static function isValidKey(string $key): bool
     {
         $array = static::toArray();
 
@@ -162,7 +162,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @param mixed $value
      *
-     * @return mixed
+     * @return false|int|string
      */
     public static function search($value)
     {
@@ -178,7 +178,7 @@ abstract class Enum implements \JsonSerializable
      * @return static
      * @throws \BadMethodCallException
      */
-    public static function __callStatic($name, $arguments): self
+    public static function __callStatic(string $name, array $arguments): self
     {
         $array = static::toArray();
         if (isset($array[$name])) {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -4,6 +4,8 @@
  * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
  */
 
+declare(strict_types=1);
+
 namespace MyCLabs\Enum;
 
 /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -43,7 +43,7 @@ abstract class Enum implements \JsonSerializable
     public function __construct($value)
     {
         if (!$this->isValid($value)) {
-            throw new \UnexpectedValueException("Value '$value' is not part of the enum " . get_called_class());
+            throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);
         }
 
         $this->value = $value;
@@ -86,7 +86,7 @@ abstract class Enum implements \JsonSerializable
      */
     final public function equals(Enum $enum = null): bool
     {
-        return $enum !== null && $this->getValue() === $enum->getValue() && get_called_class() == get_class($enum);
+        return $enum !== null && $this->getValue() === $enum->getValue() && static::class === get_class($enum);
     }
 
     /**
@@ -122,7 +122,7 @@ abstract class Enum implements \JsonSerializable
      */
     public static function toArray(): array
     {
-        $class = get_called_class();
+        $class = static::class;
         if (!array_key_exists($class, static::$cache)) {
             $reflection            = new \ReflectionClass($class);
             static::$cache[$class] = $reflection->getConstants();
@@ -185,7 +185,7 @@ abstract class Enum implements \JsonSerializable
             return new static($array[$name]);
         }
 
-        throw new \BadMethodCallException("No static method or enum constant '$name' in class " . get_called_class());
+        throw new \BadMethodCallException("No static method or enum constant '$name' in class " . static::class);
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -70,7 +70,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->value;
     }
@@ -82,7 +82,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @return bool True if Enums are equal, false if not equal
      */
-    final public function equals(Enum $enum = null)
+    final public function equals(Enum $enum = null): bool
     {
         return $enum !== null && $this->getValue() === $enum->getValue() && get_called_class() == get_class($enum);
     }
@@ -92,7 +92,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @return array
      */
-    public static function keys()
+    public static function keys(): array
     {
         return array_keys(static::toArray());
     }
@@ -102,7 +102,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @return static[] Constant name in key, Enum instance in value
      */
-    public static function values()
+    public static function values(): array
     {
         $values = array();
 
@@ -118,7 +118,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @return array Constant name in key, constant value in value
      */
-    public static function toArray()
+    public static function toArray(): array
     {
         $class = get_called_class();
         if (!array_key_exists($class, static::$cache)) {
@@ -132,11 +132,11 @@ abstract class Enum implements \JsonSerializable
     /**
      * Check if is valid enum value
      *
-     * @param $value
+     * @param mixed $value
      *
      * @return bool
      */
-    public static function isValid($value)
+    public static function isValid($value): bool
     {
         return in_array($value, static::toArray(), true);
     }
@@ -144,11 +144,11 @@ abstract class Enum implements \JsonSerializable
     /**
      * Check if is valid enum key
      *
-     * @param $key
+     * @param mixed $key
      *
      * @return bool
      */
-    public static function isValidKey($key)
+    public static function isValidKey($key): bool
     {
         $array = static::toArray();
 
@@ -158,7 +158,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Return key for value
      *
-     * @param $value
+     * @param mixed $value
      *
      * @return mixed
      */
@@ -176,7 +176,7 @@ abstract class Enum implements \JsonSerializable
      * @return static
      * @throws \BadMethodCallException
      */
-    public static function __callStatic($name, $arguments)
+    public static function __callStatic($name, $arguments): self
     {
         $array = static::toArray();
         if (isset($array[$name])) {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -31,7 +31,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @var array
      */
-    protected static $cache = array();
+    protected static $cache = [];
 
     /**
      * Creates a new value of some type
@@ -104,7 +104,7 @@ abstract class Enum implements \JsonSerializable
      */
     public static function values(): array
     {
-        $values = array();
+        $values = [];
 
         foreach (static::toArray() as $key => $value) {
             $values[$key] = new static($value);

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -262,4 +262,19 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertJsonStringEqualsJsonString('""',    json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_EMPTY_STRING)));
         $this->assertJsonStringEqualsJsonString('false', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE)));
     }
+
+    public function testConstantVisibilityDoesNotMatterForCreation()
+    {
+        $foo = EnumVisibility::FOO();
+        $this->assertEquals('foo', $foo->getValue());
+
+        $bar = EnumVisibility::BAR();
+        $this->assertEquals('bar', $bar->getValue());
+
+        $baz = EnumVisibility::BAZ();
+        $this->assertEquals('baz', $baz->getValue());
+
+        $buz = EnumVisibility::BUZ();
+        $this->assertEquals('buz', $buz->getValue());
+    }
 }

--- a/tests/EnumVisibility.php
+++ b/tests/EnumVisibility.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MyCLabs\Tests\Enum;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Class EnumVisibility
+ *
+ * @method static EnumFixture FOO()
+ * @method static EnumFixture BAR()
+ * @method static EnumFixture BAZ()
+ * @method static EnumFixture BUZ()
+ *
+ * @author Bram Van der Sype <bram.vandersype@gmail.com>
+ */
+class EnumVisibility extends Enum
+{
+    const FOO = 'foo';
+    public const BAR = 'bar';
+    protected const BAZ = 'baz';
+    private const BUZ = 'buz';
+}


### PR DESCRIPTION
After seeing https://github.com/myclabs/php-enum/issues/70, I decided to open this PR. While I personally understand the idea of this library being a building block and wanting to support older PHP versions, there's also nothing wrong with trying to go forward. 

This could be the start of a 2.0.0 version maybe? 

I've also tried to address https://github.com/myclabs/php-enum/issues/66 by improving the docblocks here and there.