### PR TITLE
Fix validating key with null value

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -150,7 +150,7 @@ abstract class Enum implements \JsonSerializable
     {
         $array = static::toArray();
 
-        return isset($array[$key]);
+        return isset($array[$key]) || \array_key_exists($key, $array);
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -190,6 +190,7 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertTrue(EnumFixture::isValidKey('FOO'));
         $this->assertFalse(EnumFixture::isValidKey('BAZ'));
+        $this->assertTrue(EnumFixture::isValidKey('PROBLEMATIC_NULL'));
     }
 
     /**


### PR DESCRIPTION
I found another bug:

If my enumeration contains a constant with the value "null", then the `isValidKey()` method incorrectly checks the validity:

```php
<?php

final class MyEnum extends \MyCLabs\Enum\Enum
{
    public const UNDEFINED = null;
}

$valid = MyEnum::isValidKey('UNDEFINED'); // will return false because of `isset` checking
```