### PR TITLE
 Create instance of enum from same enum in constructor

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -40,6 +40,12 @@ abstract class Enum implements \JsonSerializable
      */
     public function __construct($value)
     {
+        if ($value instanceof static) {
+            $this->value = $value->getValue();
+
+            return;
+        }
+
         if (!$this->isValid($value)) {
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . \get_called_class());
         }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -281,6 +281,15 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse((new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE))->jsonSerialize());
     }
 
+    public function testConstructWithSameEnumArgument()
+    {
+        $enum = new EnumFixture(EnumFixture::FOO);
+
+        $enveloped = new EnumFixture($enum);
+
+        $this->assertEquals($enum, $enveloped);
+    }
+
     private function assertJsonEqualsJson($json1, $json2)
     {
         $this->assertJsonStringEqualsJsonString($json1, $json2);


### PR DESCRIPTION
**What?**  - New feature
**Will BC break** - No

Problem:

Lets create MyEnum

```php
<?php

final class MyEnum extends \MyCLabs\Enum\Enum
{
    public const MY_VALUE = 'test-value';
}
```

Trying to create instance:
```php
<?php

$enum = new MyEnum(MyEnum::MY_VALUE); // perfectly created
``` 

And what if you create an enumeration from the same enumeration?

```php
<?php

$sameEnum = new MyEnum($enum); // will catch semantically incorrect exception
```

Thrown exception:
`Value 'test-value' is not part of MyEnum`. But 'test-value' IS part of MyEnum.
This message looks like because `__toString()` method returns property `value` in string type if it is not override

This PR add simple logic to checking argument in constructor on instance of static and not throw exception if it is.
