### PR TITLE
 Add ext-json to requirements for package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         }
     },
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35|^5.7|^6.0",


### PR DESCRIPTION
If try use jsonserialize without enabled json extension in php you will catch an error. This PR add json to requirements. It will prevent installation if json not enabled on php