### PR TITLE
Update PHP requirement for using private keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class Action extends Enum
 }
 ```
 
-Note the `private` keyword requires PHP > 7.1, you can omit it on PHP 7.0.
+Note the `private` keyword requires PHP 7.1 or higher, you can omit it on PHP 7.0.
 
 ## Usage
 


### PR DESCRIPTION
"PHP > 7.1" implies you need a version above 7.1 whereas this syntax was added as part of PHP 7.1. I've modified the text to make this clearer in the readme.