### PR TITLE
Change "equals()" method to accept anything as a parameter

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -80,15 +80,18 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
-     * Compares one Enum with another.
+     * Determines if Enum should be considered equal with the variable passed as a parameter.
+     * Returns false if an argument is an object of different class or not an object.
      *
      * This method is final, for more information read https://github.com/myclabs/php-enum/issues/4
      *
-     * @return bool True if Enums are equal, false if not equal
+     * @return bool
      */
-    final public function equals(Enum $enum = null)
+    final public function equals($variable = null)
     {
-        return $enum !== null && $this->getValue() === $enum->getValue() && \get_called_class() === \get_class($enum);
+        return $variable instanceof self
+            && $this->getValue() === $variable->getValue()
+            && \get_called_class() === \get_class($variable);
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -224,11 +224,15 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $foo = new EnumFixture(EnumFixture::FOO);
         $number = new EnumFixture(EnumFixture::NUMBER);
         $anotherFoo = new EnumFixture(EnumFixture::FOO);
+        $objectOfDifferentClass = new \stdClass();
+        $notAnObject = 'foo';
 
         $this->assertTrue($foo->equals($foo));
         $this->assertFalse($foo->equals($number));
         $this->assertTrue($foo->equals($anotherFoo));
         $this->assertFalse($foo->equals(null));
+        $this->assertFalse($foo->equals($objectOfDifferentClass));
+        $this->assertFalse($foo->equals($notAnObject));
     }
 
     /**


### PR DESCRIPTION
Makes "equals()" method accept anything as a parameter. It will return false if an argument is an object of different class or not an object.

One of the two PRs needed to fix https://github.com/myclabs/php-enum/issues/86