### PR TITLE
Add a comparator to help with writing tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="./vendor/autoload.php">
+         bootstrap="./tests/bootstrap.php">
     <testsuites>
         <testsuite name="PHP Enum Test Suite">
             <directory suffix=".php">./tests</directory>

--- a/src/PHPUnit/Comparator.php
+++ b/src/PHPUnit/Comparator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace MyCLabs\Enum\PHPUnit;
+
+use MyCLabs\Enum\Enum;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/**
+ * Use this Comparator to get nice output when using PHPUnit assertEquals() with Enums.
+ *
+ * Add this to your PHPUnit bootstrap PHP file:
+ *
+ * \SebastianBergmann\Comparator\Factory::getInstance()->register(new \MyCLabs\Enum\PHPUnit\Comparator());
+ */
+final class Comparator extends \SebastianBergmann\Comparator\Comparator
+{
+    public function accepts($expected, $actual)
+    {
+        return $expected instanceof Enum && (
+                $actual instanceof Enum || $actual === null
+            );
+    }
+
+    /**
+     * @param Enum $expected
+     * @param Enum|null $actual
+     */
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
+    {
+        if ($expected->equals($actual)) {
+            return;
+        }
+
+        throw new ComparisonFailure(
+            $expected,
+            $actual,
+            $this->formatEnum($expected),
+            $this->formatEnum($actual),
+            false,
+            'Failed asserting that two Enums are equal.'
+        );
+    }
+
+    private function formatEnum(Enum $enum = null)
+    {
+        if ($enum === null) {
+            return "null";
+        }
+
+        return get_class($enum)."::{$enum->getKey()}()";
+    }
+}

--- a/src/PHPUnit/Comparator.php
+++ b/src/PHPUnit/Comparator.php
@@ -24,6 +24,8 @@ final class Comparator extends \SebastianBergmann\Comparator\Comparator
     /**
      * @param Enum $expected
      * @param Enum|null $actual
+     *
+     * @return void
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+\SebastianBergmann\Comparator\Factory::getInstance()->register(new \MyCLabs\Enum\PHPUnit\Comparator());


### PR DESCRIPTION
PHPUnit offers the ability to add custom comparators. In particular these offer the ability to add nice error messages:

![Screen Shot 2019-05-02 at 13 29 35](https://user-images.githubusercontent.com/701299/57072620-9d5a6f80-6cde-11e9-90d6-81f5016bb6c4.png)

This is a rough PR as a first draft, if you are interested in this feature please let me know and I'll polish it up. 