### PR TITLE
Implement "valueOf()" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Static methods:
 - `isValid()` Check if tested value is valid on enum set
 - `isValidKey()` Check if tested key is valid on enum set
 - `search()` Return key for searched value
+- `valueOf()` Return Enum for searched key
 
 ### Static methods
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -175,6 +175,25 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * Return value for key
+     *
+     * @param $key
+     *
+     * @return mixed
+     * @throws \InvalidArgumentException
+     */
+    public static function valueOf($key)
+    {
+        if (!self::isValidKey($key)) {
+            throw new \InvalidArgumentException("No enum constant '$key' in class " . \get_called_class());
+        }
+        $array = static::toArray();
+        $value = $array[$key];
+
+        return new static($value);
+    }
+
+    /**
      * Returns a value when called statically like so: MyEnum::SOME_VALUE() given SOME_VALUE is a class constant
      *
      * @param string $name

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -217,6 +217,37 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * valueOf()
+     * @dataProvider valueOfProvider
+     */
+    public function testValueOf($key, $expected)
+    {
+        $this->assertTrue(EnumFixture::valueOf($key)->equals($expected));
+    }
+
+    public function valueOfProvider()
+    {
+        return array(
+            array('FOO', new EnumFixture('foo')),
+            array('BAR', new EnumFixture('bar')),
+            array('NUMBER', new EnumFixture(42)),
+            array('PROBLEMATIC_NUMBER', new EnumFixture(0)),
+            array('PROBLEMATIC_NULL', new EnumFixture(null)),
+            array('PROBLEMATIC_EMPTY_STRING', new EnumFixture('')),
+            array('PROBLEMATIC_BOOLEAN_FALSE', new EnumFixture(false)),
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage No enum constant 'NONEXISTENT_KEY' in class MyCLabs\Tests\Enum\EnumFixture
+     */
+    public function testValueOfWithInvalidKey()
+    {
+        EnumFixture::valueOf('NONEXISTENT_KEY');
+    }
+
+    /**
      * equals()
      */
     public function testEquals()


### PR DESCRIPTION
This PR proposes the addition of a `valueOf()` method, which is useful for when we need to construct an Enum from a key instead of a value.

A similar method is available in [Java](https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/lang/Enum.html#valueOf(java.lang.Class,java.lang.String)) for example. My implementation has been modeled mostly after it.

