### PR TITLE
Adds own toString() method

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -74,6 +74,14 @@ abstract class Enum implements \JsonSerializable
      */
     public function __toString()
     {
+        return $this->toString();
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
         return (string)$this->value;
     }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -64,9 +64,18 @@ class EnumTest extends \PHPUnit\Framework\TestCase
      * __toString()
      * @dataProvider toStringProvider
      */
-    public function testToString($expected, $enumObject)
+    public function testMagicToString($expected, $enumObject)
     {
         $this->assertSame($expected, (string) $enumObject);
+    }
+
+    /**
+     * toString()
+     * @dataProvider toStringProvider
+     */
+    public function testToString($expected, $enumObject)
+    {
+        $this->assertSame($expected, $enumObject->toString());
     }
 
     public function toStringProvider()


### PR DESCRIPTION
The idea of adding separate method `toString` is based on comment 
https://github.com/ShittySoft/symfony-live-berlin-2018-doctrine-tutorial/pull/3#issuecomment-460441229