### PR TITLE
Add the ability to have title case formatted labels

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -70,6 +70,32 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * Returns a human friendly title cased label based on the key name
+     *
+     * return @string
+     */
+    public function getLabel()
+    {
+        return static::keyToTitleCase($this->getKey());
+    }
+
+    /**
+     * Gets human friendly title cased labels based on all keys
+     *
+     * @return string[]
+     */
+    public static function getLabels()
+    {
+        $labels = [];
+
+        foreach (static::toArray() as $key => $value) {
+            $labels[static::keyToTitleCase($key)] = $value;
+        }
+
+        return $labels;
+    }
+
+    /**
      * @return string
      */
     public function __toString()
@@ -201,5 +227,21 @@ abstract class Enum implements \JsonSerializable
     public function jsonSerialize()
     {
         return $this->getValue();
+    }
+
+    /**
+     * Turns the const Key into title case
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    private static function keyToTitleCase($key)
+    {
+        $key_parts = explode('_', $key);
+
+        return implode(' ', array_map(function ($key) {
+            return ucfirst(mb_strtolower($key));
+        }, $key_parts));
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -39,6 +39,37 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * getLabel()
+     */
+    public function testGetLabel()
+    {
+        $foo = new EnumFixture(EnumFixture::FOO);
+        $problematicBooleanFalse = new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE);
+
+        $this->assertEquals('Foo', $foo->getLabel());
+        $this->assertEquals('Problematic Boolean False', $problematicBooleanFalse->getLabel());
+    }
+
+    /**
+     * getLabels()
+     */
+    public function testGetLabels()
+    {
+        $values = EnumFixture::getLabels();
+        $expectedValues = [
+            "Foo"                       => EnumFixture::FOO,
+            "Bar"                       => EnumFixture::BAR,
+            "Number"                    => EnumFixture::NUMBER,
+            "Problematic Number"        => EnumFixture::PROBLEMATIC_NUMBER,
+            "Problematic Null"          => EnumFixture::PROBLEMATIC_NULL,
+            "Problematic Empty String"  => EnumFixture::PROBLEMATIC_EMPTY_STRING,
+            "Problematic Boolean False" => EnumFixture::PROBLEMATIC_BOOLEAN_FALSE,
+        ];
+
+        $this->assertEquals($expectedValues, $values);
+    }
+
+    /**
      * @dataProvider invalidValueProvider
      * @expectedException \UnexpectedValueException
      * @expectedExceptionMessage is not part of the enum MyCLabs\Tests\Enum\EnumFixture


### PR DESCRIPTION
So we have a use case where it would be really nice to have the keys printed off as title cased options. 

Another benefit of this is forcing sane key naming between the domain and Enum as they're in lock step with one another.  