### PR TITLE
Add the ability to have title case formatted labels

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -222,11 +222,7 @@ abstract class Enum implements \JsonSerializable
      */
     private static function keyToTitleCase($key)
     {
-        $key_parts = explode('_', $key);
-
-        return implode(' ', array_map(function ($key) {
-            return ucfirst(strtolower($key));
-        }, $key_parts));
+        return ucwords(strtolower(str_ireplace('_', ' ', $key)));
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -70,6 +70,16 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * Returns a title cased label based on the instance bound key name
+     *
+     * return @string
+     */
+    public function getLabel()
+    {
+        return static::keyToTitleCase($this->getKey());
+    }
+
+    /**
      * @return string
      */
     public function __toString()
@@ -173,6 +183,18 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * Returns a title cased label based on a key
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public static function getLabelForValue($value)
+    {
+        return static::keyToTitleCase(static::search($value));
+    }
+
+    /**
      * Returns a value when called statically like so: MyEnum::SOME_VALUE() given SOME_VALUE is a class constant
      *
      * @param string $name
@@ -189,6 +211,22 @@ abstract class Enum implements \JsonSerializable
         }
 
         throw new \BadMethodCallException("No static method or enum constant '$name' in class " . \get_called_class());
+    }
+
+    /**
+     * Returns a title cased representation of a key
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    private static function keyToTitleCase($key)
+    {
+        $key_parts = explode('_', $key);
+
+        return implode(' ', array_map(function ($key) {
+            return ucfirst(strtolower($key));
+        }, $key_parts));
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -188,10 +188,18 @@ abstract class Enum implements \JsonSerializable
      * @param mixed $value
      *
      * @return string
+     *
+     * @throws \UnexpectedValueException
      */
     public static function getLabelForValue($value)
     {
-        return static::keyToTitleCase(static::search($value));
+        $key = static::search($value);
+
+        if (!$key) {
+            throw new \UnexpectedValueException("Value '$value' is not part of the enum " . \get_called_class());
+        }
+
+        return static::keyToTitleCase($key);
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -39,6 +39,30 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * getLabel()
+     */
+    public function testGetLabel()
+    {
+        $foo = new EnumFixture(EnumFixture::FOO);
+        $problematicBooleanFalse = new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE);
+
+        $this->assertEquals('Foo', $foo->getLabel());
+        $this->assertEquals('Problematic Boolean False', $problematicBooleanFalse->getLabel());
+    }
+
+    /**
+     * getLabelForValue()
+     */
+    public function testGetLabelForValue()
+    {
+        $this->assertEquals('Foo', EnumFixture::getLabelForValue(EnumFixture::FOO));
+        $this->assertEquals(
+            'Problematic Boolean False',
+            EnumFixture::getLabelForValue(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE)
+        );
+    }
+
+    /**
      * @dataProvider invalidValueProvider
      * @expectedException \UnexpectedValueException
      * @expectedExceptionMessage is not part of the enum MyCLabs\Tests\Enum\EnumFixture

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -63,6 +63,19 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * getLabelForValue()
+     */
+    public function testGetLabelForValueThrowsIfUnexpectedValue()
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'Value \'NON_EXISTENT_KEY\' is not part of the enum MyCLabs\Tests\Enum\EnumFixture'
+        );
+
+        EnumFixture::getLabelForValue('NON_EXISTENT_KEY');
+    }
+
+    /**
      * @dataProvider invalidValueProvider
      * @expectedException \UnexpectedValueException
      * @expectedExceptionMessage is not part of the enum MyCLabs\Tests\Enum\EnumFixture


### PR DESCRIPTION
Hi @mnapoli ! We have a use case on our team that involves pretty printing some labels from our Enums. They're often used as API values for our client and the need for pretty representation is there. Now, display / presentation may be a bit outside the realm of responsibility for this class but it also doesn't feel like too much of a stretch at the same time.

We really enjoy the fact that using the Key as a label forces sane naming conventions and keeps our Domain language and code in lock step. 

Anyways, thanks for any consideration and thank you for such a great project, we love it!
