### PR TITLE
Clarify psalm types

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -42,7 +42,6 @@ abstract class Enum implements \JsonSerializable
      * @param mixed $value
      *
      * @psalm-param T $value
-     * @psalm-suppress InvalidCast
      * @throws \UnexpectedValueException if incompatible type is given.
      */
     public function __construct($value)
@@ -52,6 +51,7 @@ abstract class Enum implements \JsonSerializable
         }
 
         if (!$this->isValid($value)) {
+            /** @psalm-suppress InvalidCast */
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);
         }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -31,7 +31,6 @@ abstract class Enum implements \JsonSerializable
     /**
      * Store existing constants in a static cache per object.
      *
-     * @psalm-pure
      *
      * @var array
      * @psalm-var array<class-string, array<string, mixed>>

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -109,6 +109,7 @@ abstract class Enum implements \JsonSerializable
      * Returns the names (keys) of all constants in the Enum class
      *
      * @psalm-external-mutation-free
+     * @psalm-return list<string>
      * @return array
      */
     public static function keys()
@@ -120,6 +121,7 @@ abstract class Enum implements \JsonSerializable
      * Returns instances of the Enum class of all Enum constants
      *
      * @psalm-external-mutation-free
+     * @psalm-return array<string, static>
      * @return static[] Constant name in key, Enum instance in value
      */
     public static function values()

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -41,12 +41,13 @@ abstract class Enum implements \JsonSerializable
      *
      * @param mixed $value
      *
-     * @psalm-param T $value
+     * @psalm-param static<T>|T $value
      * @throws \UnexpectedValueException if incompatible type is given.
      */
     public function __construct($value)
     {
         if ($value instanceof static) {
+           /** @psalm-var T */
             $value = $value->getValue();
         }
 
@@ -55,6 +56,7 @@ abstract class Enum implements \JsonSerializable
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);
         }
 
+        /** @psalm-var T */
         $this->value = $value;
     }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -31,6 +31,8 @@ abstract class Enum implements \JsonSerializable
     /**
      * Store existing constants in a static cache per object.
      *
+     * @psalm-pure
+     *
      * @var array
      * @psalm-var array<class-string, array<string, mixed>>
      */
@@ -39,6 +41,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Creates a new value of some type
      *
+     * @psalm-pure
      * @param mixed $value
      *
      * @psalm-param static<T>|T $value
@@ -61,6 +64,7 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * @psalm-pure
      * @return mixed
      * @psalm-return T
      */
@@ -72,7 +76,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns the enum key (i.e. the constant name).
      *
-     * @psalm-external-mutation-free
+     * @psalm-pure
      * @return mixed
      */
     public function getKey()
@@ -81,6 +85,7 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * @psalm-pure
      * @psalm-suppress InvalidCast
      * @return string
      */
@@ -95,6 +100,7 @@ abstract class Enum implements \JsonSerializable
      *
      * This method is final, for more information read https://github.com/myclabs/php-enum/issues/4
      *
+     * @psalm-pure
      * @psalm-param mixed $variable
      * @return bool
      */
@@ -108,7 +114,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns the names (keys) of all constants in the Enum class
      *
-     * @psalm-external-mutation-free
+     * @psalm-pure
      * @psalm-return list<string>
      * @return array
      */
@@ -120,7 +126,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns instances of the Enum class of all Enum constants
      *
-     * @psalm-external-mutation-free
+     * @psalm-pure
      * @psalm-return array<string, static>
      * @return static[] Constant name in key, Enum instance in value
      */
@@ -139,7 +145,8 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns all possible values as an array
      *
-     * @psalm-external-mutation-free
+     * @psalm-pure
+     *
      * @psalm-return array<string, mixed>
      * @return array Constant name in key, constant value in value
      */
@@ -160,7 +167,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @param $value
      * @psalm-param mixed $value
-     * @psalm-external-mutation-free
+     * @psalm-pure
      * @return bool
      */
     public static function isValid($value)
@@ -173,7 +180,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @param $key
      * @psalm-param string $key
-     * @psalm-external-mutation-free
+     * @psalm-pure
      * @return bool
      */
     public static function isValidKey($key)
@@ -189,7 +196,7 @@ abstract class Enum implements \JsonSerializable
      * @param $value
      *
      * @psalm-param mixed $value
-     * @psalm-external-mutation-free
+     * @psalm-pure
      * @return mixed
      */
     public static function search($value)
@@ -204,7 +211,7 @@ abstract class Enum implements \JsonSerializable
      * @param array  $arguments
      *
      * @return static
-     * @psalm-external-mutation-free
+     * @psalm-pure
      * @throws \BadMethodCallException
      */
     public static function __callStatic($name, $arguments)
@@ -223,6 +230,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @return mixed
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @psalm-pure
      */
     public function jsonSerialize()
     {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -146,6 +146,7 @@ abstract class Enum implements \JsonSerializable
      * Returns all possible values as an array
      *
      * @psalm-pure
+     * @psalm-suppress ImpureStaticProperty
      *
      * @psalm-return array<string, mixed>
      * @return array Constant name in key, constant value in value

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -128,6 +128,7 @@ abstract class Enum implements \JsonSerializable
     {
         $values = array();
 
+        /** @psalm-var T $value */
         foreach (static::toArray() as $key => $value) {
             $values[$key] = new static($value);
         }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -70,7 +70,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns the enum key (i.e. the constant name).
      *
-     * @psalm-pure
+     * @psalm-external-mutation-free
      * @return mixed
      */
     public function getKey()
@@ -106,6 +106,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns the names (keys) of all constants in the Enum class
      *
+     * @psalm-external-mutation-free
      * @return array
      */
     public static function keys()
@@ -116,6 +117,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns instances of the Enum class of all Enum constants
      *
+     * @psalm-external-mutation-free
      * @return static[] Constant name in key, Enum instance in value
      */
     public static function values()
@@ -132,7 +134,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * Returns all possible values as an array
      *
-     * @psalm-pure
+     * @psalm-external-mutation-free
      * @psalm-return array<string, mixed>
      * @return array Constant name in key, constant value in value
      */
@@ -153,7 +155,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @param $value
      * @psalm-param mixed $value
-     *
+     * @psalm-external-mutation-free
      * @return bool
      */
     public static function isValid($value)
@@ -166,7 +168,7 @@ abstract class Enum implements \JsonSerializable
      *
      * @param $key
      * @psalm-param string $key
-     *
+     * @psalm-external-mutation-free
      * @return bool
      */
     public static function isValidKey($key)
@@ -182,7 +184,7 @@ abstract class Enum implements \JsonSerializable
      * @param $value
      *
      * @psalm-param mixed $value
-     * @psalm-pure
+     * @psalm-external-mutation-free
      * @return mixed
      */
     public static function search($value)
@@ -197,6 +199,7 @@ abstract class Enum implements \JsonSerializable
      * @param array  $arguments
      *
      * @return static
+     * @psalm-external-mutation-free
      * @throws \BadMethodCallException
      */
     public static function __callStatic($name, $arguments)


### PR DESCRIPTION
I noticed that some of the Psalm types added in #111 could be made more precise, so I cleaned them up a bit.

I'm very interested in feedback on my decision to mark all the static methods as [`external-mutation-free`](https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-external-mutation-free) rather than [`mutation-free`](https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-mutation-free). It's more correct to use `external-mutation-free` as I've done, but then it's invalid to call the Enum functions in immutable contexts:
```php
EnumSubclass::ENUM_VALUE()
```
is disallowed in a function marked `psalm-immutable`, because of the internal mutation of the cache array. The mutation seems insignificant, since it could be omitted with no change to the results (other than in speed), so I'd like to find a way around this.

I can see two approaches which would allow the use of Enums in immutable contexts (three, if you count the user ignoring the Psalm errors):
1. Lie to Psalm and tell it that `toArray` is immmutable. This seems tolerable (despite how bad a practice overriding the typechecker is) because the mutation is entirely memoization. If PHP were a lazy language, no caching would be necessary in the first place.
2. Do the reflection up-front. Run `toArray` in the constructor and look up the value there. `__callStatic` can in fact be marked `pure` if this approach is taken. I've written the code for this in the https://github.com/iFixit/php-enum/compare/clarify-psalm-types...iFixit:make-callstatic-pure branch; feel free to ask for a PR from that if you like that approach.