### PR TITLE
Psalm: do not collide with doctrine templates

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -15,7 +15,7 @@ namespace MyCLabs\Enum;
  * @author Daniel Costa <danielcosta@gmail.com>
  * @author Mirosław Filip <mirfilip@gmail.com>
  *
- * @template T
+ * @psalm-template T
  * @psalm-immutable
  */
 abstract class Enum implements \JsonSerializable


### PR DESCRIPTION
This *should* be the only needed fix to stop psalm annotations from being picked up as doctrine annotations.

Note: I would like verification from someone as I did not test this with doctrine.

Closes: #113