### PR TITLE
Ignore private constants

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -145,6 +145,7 @@ abstract class Enum implements \JsonSerializable
      * Returns all possible values as an array
      *
      * @psalm-pure
+     * @psalm-suppress ImpureMethodCall
      * @psalm-suppress ImpureStaticProperty
      *
      * @psalm-return array<string, mixed>

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -155,8 +155,14 @@ abstract class Enum implements \JsonSerializable
         $class = static::class;
 
         if (!isset(static::$cache[$class])) {
-            $reflection            = new \ReflectionClass($class);
-            static::$cache[$class] = $reflection->getConstants();
+            static::$cache[$class] = [];
+            $reflection = new \ReflectionClass($class);
+
+            foreach ($reflection->getReflectionConstants() as $constant) {
+                if (!$constant->isPrivate()) {
+                    static::$cache[$class][$constant->getName()] = $constant->getValue();
+                }
+            }
         }
 
         return static::$cache[$class];

--- a/tests/EnumFixture.php
+++ b/tests/EnumFixture.php
@@ -20,6 +20,8 @@ use MyCLabs\Enum\Enum;
  * @method static EnumFixture PROBLEMATIC_EMPTY_STRING()
  * @method static EnumFixture PROBLEMATIC_BOOLEAN_FALSE()
  *
+ * @method static EnumFixture SCOPE_PROTECTED()
+ *
  * @author Daniel Costa <danielcosta@gmail.com>
  * @author Mirosław Filip <mirfilip@gmail.com>
  */
@@ -36,4 +38,7 @@ class EnumFixture extends Enum
     const PROBLEMATIC_NULL = null;
     const PROBLEMATIC_EMPTY_STRING = '';
     const PROBLEMATIC_BOOLEAN_FALSE = false;
+
+    protected const SCOPE_PROTECTED = "protected";
+    private const SCOPE_PRIVATE = "private";
 }


### PR DESCRIPTION
Update use of reflection to only populate the cache with public and protected constants, ie. those that would be visible to the abstract class if not for the use of reflection. Private constants will now be treated as invalid - they no longer appear in `toArray()`, can't be instantiated using static method calls, and throw an exception as normal when constructing the enum with the private value hard-coded.

Resolves #120.