### PR TITLE
Add getKey() return type as string

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -83,9 +83,8 @@ abstract class Enum implements \JsonSerializable
      * Returns the enum key (i.e. the constant name).
      *
      * @psalm-pure
-     * @return mixed
      */
-    public function getKey()
+    public function getKey(): string
     {
         return static::search($this->value);
     }
@@ -200,11 +199,11 @@ abstract class Enum implements \JsonSerializable
     /**
      * Return key for value
      *
-     * @param $value
+     * @param mixed $value
      *
      * @psalm-param mixed $value
      * @psalm-pure
-     * @return mixed
+     * @return string|false
      */
     public static function search($value)
     {


### PR DESCRIPTION
Method `Enum::getKey()` will always return `string` as it's already called on existing instance.