### PR TITLE
Remove unused psalm-suppress

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -54,7 +54,6 @@ abstract class Enum implements \JsonSerializable
         }
 
         if (!$this->isValid($value)) {
-            /** @psalm-suppress InvalidCast */
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);
         }
 


### PR DESCRIPTION
When using psalm in my project with `findUnusedPsalmSuppress="true"`, I get this error:

> ERROR: UnusedPsalmSuppress - vendor/myclabs/php-enum/src/Enum.php:57:33 - This suppression is never used (see https://psalm.dev/207)
>             /** @psalm-suppress InvalidCast */
