### PR TITLE
Added new named constructor to create enum from mixed

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -61,12 +61,22 @@ abstract class Enum implements \JsonSerializable
             $value = $value->getValue();
         }
 
-        if (!$this->isValid($value)) {
-            throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);
-        }
+        static::assertValidValue($value);
 
         /** @psalm-var T */
         $this->value = $value;
+    }
+
+    /**
+     * @param mixed $value
+     * @return static
+     * @psalm-return static<T>
+     */
+    public static function from($value): self
+    {
+        static::assertValidValue($value);
+
+        return new static($value);
     }
 
     /**
@@ -175,11 +185,25 @@ abstract class Enum implements \JsonSerializable
      * @param $value
      * @psalm-param mixed $value
      * @psalm-pure
+     * @psalm-assert-if-true T $value
      * @return bool
      */
     public static function isValid($value)
     {
         return \in_array($value, static::toArray(), true);
+    }
+
+    /**
+     * Asserts valid enum value
+     *
+     * @psalm-pure
+     * @psalm-assert T $value
+     */
+    public static function assertValidValue($value): void
+    {
+        if (!static::isValid($value)) {
+            throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);
+        }
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -49,6 +49,18 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @dataProvider invalidValueProvider
+     * @param mixed $value
+     */
+    public function testFailToCreateEnumWithInvalidValueThroughNamedConstructor($value): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('is not part of the enum MyCLabs\Tests\Enum\EnumFixture');
+
+        EnumFixture::from($value);
+    }
+
+    /**
      * Contains values not existing in EnumFixture
      * @return array
      */
@@ -331,5 +343,20 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage("Value 'value' is not part of the enum MyCLabs\Tests\Enum\EnumFixture");
         $inheritedEnumFixture = InheritedEnumFixture::VALUE();
         new EnumFixture($inheritedEnumFixture);
+    }
+
+    /**
+     * @dataProvider isValidProvider
+     */
+    public function testAssertValidValue($value, $isValid): void
+    {
+        if (!$isValid) {
+            $this->expectException(\UnexpectedValueException::class);
+            $this->expectExceptionMessage("Value '$value' is not part of the enum " . EnumFixture::class);
+        }
+
+        EnumFixture::assertValidValue($value);
+
+        self::assertTrue(EnumFixture::isValid($value));
     }
 }


### PR DESCRIPTION
The current implementation of Enum requires to pass a valid enum value to class constructor. With this new named constructor we can just pass any value to enum and get an instance or unexpected value exception. In the end it's like the class constructor except for it makes psalm happy.