### PR TITLE
Improve getKey method performance

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -88,9 +88,9 @@ abstract class Enum implements \JsonSerializable
      */
     public static function from($value): self
     {
-        static::assertValidValue($value);
+        $key = static::assertValidValueReturningKey($value);
 
-        return new static($value);
+        return self::__callStatic($key, []);
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -198,7 +198,7 @@ abstract class Enum implements \JsonSerializable
      * @psalm-pure
      * @psalm-assert T $value
      */
-    public static function assertValidValue($value): void
+    private static function assertValidValue($value): void
     {
         if (!static::isValid($value)) {
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -29,6 +29,13 @@ abstract class Enum implements \JsonSerializable
     protected $value;
 
     /**
+     * Enum key, the constant name
+     *
+     * @var string
+     */
+    private $key;
+
+    /**
      * Store existing constants in a static cache per object.
      *
      *
@@ -61,7 +68,7 @@ abstract class Enum implements \JsonSerializable
             $value = $value->getValue();
         }
 
-        static::assertValidValue($value);
+        $this->key = static::assertValidValue($value);
 
         /** @psalm-var T */
         $this->value = $value;
@@ -94,9 +101,9 @@ abstract class Enum implements \JsonSerializable
      *
      * @psalm-pure
      */
-    public function getKey(): string
+    public function getKey()
     {
-        return static::search($this->value);
+        return $this->key ?? ($this->key = static::search($this->value));
     }
 
     /**
@@ -198,11 +205,13 @@ abstract class Enum implements \JsonSerializable
      * @psalm-pure
      * @psalm-assert T $value
      */
-    private static function assertValidValue($value): void
+    private static function assertValidValue($value): string
     {
-        if (!static::isValid($value)) {
+        if (false === ($key = static::search($value))) {
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);
         }
+
+        return $key;
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -74,6 +74,13 @@ abstract class Enum implements \JsonSerializable
         $this->value = $value;
     }
 
+    public function __wakeup()
+    {
+        if ($this->key === null) {
+            $this->key = static::search($this->value);
+        }
+    }
+
     /**
      * @param mixed $value
      * @return static
@@ -100,10 +107,11 @@ abstract class Enum implements \JsonSerializable
      * Returns the enum key (i.e. the constant name).
      *
      * @psalm-pure
+     * @return string
      */
     public function getKey()
     {
-        return $this->key ?? ($this->key = static::search($this->value));
+        return $this->key;
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -68,7 +68,7 @@ abstract class Enum implements \JsonSerializable
             $value = $value->getValue();
         }
 
-        $this->key = static::assertValidValue($value);
+        $this->key = static::assertValidValueReturningKey($value);
 
         /** @psalm-var T */
         $this->value = $value;
@@ -213,7 +213,18 @@ abstract class Enum implements \JsonSerializable
      * @psalm-pure
      * @psalm-assert T $value
      */
-    private static function assertValidValue($value): string
+    public static function assertValidValue($value): void
+    {
+        self::assertValidValueReturningKey($value);
+    }
+
+    /**
+     * Asserts valid enum value
+     *
+     * @psalm-pure
+     * @psalm-assert T $value
+     */
+    private static function assertValidValueReturningKey($value): string
     {
         if (false === ($key = static::search($value))) {
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -76,9 +76,8 @@ abstract class Enum implements \JsonSerializable
      * Returns the enum key (i.e. the constant name).
      *
      * @psalm-pure
-     * @return mixed
      */
-    public function getKey()
+    public function getKey(): string
     {
         return static::search($this->value);
     }
@@ -193,11 +192,11 @@ abstract class Enum implements \JsonSerializable
     /**
      * Return key for value
      *
-     * @param $value
+     * @param mixed $value
      *
      * @psalm-param mixed $value
      * @psalm-pure
-     * @return mixed
+     * @return string|false
      */
     public static function search($value)
     {

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -60,6 +60,14 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         EnumFixture::from($value);
     }
 
+    public function testFailToCreateEnumWithEnumItselfThroughNamedConstructor(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage("Value 'foo' is not part of the enum " . EnumFixture::class);
+
+        EnumFixture::from(EnumFixture::FOO());
+    }
+
     /**
      * Contains values not existing in EnumFixture
      * @return array
@@ -343,20 +351,5 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage("Value 'value' is not part of the enum MyCLabs\Tests\Enum\EnumFixture");
         $inheritedEnumFixture = InheritedEnumFixture::VALUE();
         new EnumFixture($inheritedEnumFixture);
-    }
-
-    /**
-     * @dataProvider isValidProvider
-     */
-    public function testAssertValidValue($value, $isValid): void
-    {
-        if (!$isValid) {
-            $this->expectException(\UnexpectedValueException::class);
-            $this->expectExceptionMessage("Value '$value' is not part of the enum " . EnumFixture::class);
-        }
-
-        EnumFixture::assertValidValue($value);
-
-        self::assertTrue(EnumFixture::isValid($value));
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -324,7 +324,8 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     {
         // split string for Pretty CI: "Line exceeds 120 characters"
         $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787'.
-            '4757265223a313a7b733a383a22002a0076616c7565223b733a333a22666f6f223b7d';
+            '4757265223a323a7b733a383a22002a0076616c7565223b733a333a22666f6f223b73'.
+            '3a32323a22004d79434c6162735c456e756d5c456e756d006b6579223b733a333a22464f4f223b7d';
 
         $this->assertEquals($bin, bin2hex(serialize(EnumFixture::FOO())));
     }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -369,4 +369,19 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $inheritedEnumFixture = InheritedEnumFixture::VALUE();
         new EnumFixture($inheritedEnumFixture);
     }
+
+    /**
+     * @dataProvider isValidProvider
+     */
+    public function testAssertValidValue($value, $isValid): void
+    {
+        if (!$isValid) {
+            $this->expectException(\UnexpectedValueException::class);
+            $this->expectExceptionMessage("Value '$value' is not part of the enum " . EnumFixture::class);
+        }
+
+        EnumFixture::assertValidValue($value);
+
+        self::assertTrue(EnumFixture::isValid($value));
+    }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -330,7 +330,7 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($bin, bin2hex(serialize(EnumFixture::FOO())));
     }
 
-    public function testUnserialize()
+    public function testUnserializeVersionWithoutKey()
     {
         // split string for Pretty CI: "Line exceeds 120 characters"
         $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787'.
@@ -341,6 +341,22 @@ class EnumTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(EnumFixture::FOO, $value->getValue());
         $this->assertTrue(EnumFixture::FOO()->equals($value));
+        $this->assertTrue(EnumFixture::FOO() == $value);
+    }
+
+    public function testUnserialize()
+    {
+        // split string for Pretty CI: "Line exceeds 120 characters"
+        $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787'.
+            '4757265223a323a7b733a383a22002a0076616c7565223b733a333a22666f6f223b73'.
+            '3a32323a22004d79434c6162735c456e756d5c456e756d006b6579223b733a333a22464f4f223b7d';
+
+        /* @var $value EnumFixture */
+        $value = unserialize(pack('H*', $bin));
+
+        $this->assertEquals(EnumFixture::FOO, $value->getValue());
+        $this->assertTrue(EnumFixture::FOO()->equals($value));
+        $this->assertTrue(EnumFixture::FOO() == $value);
     }
 
     /**


### PR DESCRIPTION
Few months ago when I profile an application during some performance tests, I found that using `getKey()` was taking more CPU than expected and switching to `getValue()` for that case solved the issue; it was for logging.
For that specific case, the enum value object wasn't recreated but `getKey()` was called multiple times on the duration of a script.

In this change, the key is stored in constructor using the same cost basically.

I added to the branch the commit of @simPod from #123 as the changes there was something I also changed almost the same so he could have the credits.