### PR TITLE
Added new type-safe API that allows validating a given value against a given `class-string<Enum>`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "1.*",
-        "vimeo/psalm": "^4.6.2"
+        "vimeo/psalm": "4.6.2"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,4 +10,9 @@
             <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
-    resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    restrictReturnTypes="true"
+    findUnusedPsalmSuppress="true"
+    totallyTyped="true"
 >
     <projectFiles>
         <directory name="src" />
@@ -16,8 +17,6 @@
     </projectFiles>
 
     <issueHandlers>
-        <MixedAssignment errorLevel="info" />
-
         <ImpureStaticProperty>
             <!-- self::$... usages in Enum are used to populate an internal cache, and cause no side-effects -->
             <errorLevel type="suppress">

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -93,6 +93,7 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * @psalm-pure
      * @param mixed $value
      * @return static
      * @psalm-return static

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -95,7 +95,7 @@ abstract class Enum implements \JsonSerializable
     /**
      * @param mixed $value
      * @return static
-     * @psalm-return static<T>
+     * @psalm-return static
      */
     public static function from($value): self
     {
@@ -212,7 +212,6 @@ abstract class Enum implements \JsonSerializable
      * @param $value
      * @psalm-param mixed $value
      * @psalm-pure
-     * @psalm-assert-if-true T $value
      * @return bool
      */
     public static function isValid($value)
@@ -224,7 +223,6 @@ abstract class Enum implements \JsonSerializable
      * Asserts valid enum value
      *
      * @psalm-pure
-     * @psalm-assert T $value
      * @param mixed $value
      */
     public static function assertValidValue($value): void
@@ -236,7 +234,6 @@ abstract class Enum implements \JsonSerializable
      * Asserts valid enum value
      *
      * @psalm-pure
-     * @psalm-assert T $value
      * @param mixed $value
      * @return string
      */

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -212,6 +212,8 @@ abstract class Enum implements \JsonSerializable
      * @psalm-param mixed $value
      * @psalm-pure
      * @return bool
+     *
+     * deprecated use {@see Enum::isValidEnumValue()} instead
      */
     public static function isValid($value)
     {
@@ -222,11 +224,41 @@ abstract class Enum implements \JsonSerializable
      * Asserts valid enum value
      *
      * @psalm-pure
+     * @psalm-template CheckedValueType
+     * @psalm-param class-string<self<CheckedValueType>> $enumType
      * @param mixed $value
+     * @psalm-assert-if-true CheckedValueType $value
+     */
+    public static function isValidEnumValue(string $enumType, $value): bool
+    {
+        return $enumType::isValid($value);
+    }
+
+    /**
+     * Asserts valid enum value
+     *
+     * @psalm-pure
+     * @param mixed $value
+     *
+     * deprecated use {@see Enum::assertValidEnumValue()} instead
      */
     public static function assertValidValue($value): void
     {
         self::assertValidValueReturningKey($value);
+    }
+
+    /**
+     * Asserts valid enum value
+     *
+     * @psalm-pure
+     * @psalm-template ValueType
+     * @psalm-param class-string<self<ValueType>> $enumType
+     * @param mixed $value
+     * @psalm-assert ValueType $value
+     */
+    public static function assertValidEnumValue(string $enumType, $value): void
+    {
+        $enumType::assertValidValue($value);
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -128,7 +128,6 @@ abstract class Enum implements \JsonSerializable
 
     /**
      * @psalm-pure
-     * @psalm-suppress InvalidCast
      * @return string
      */
     public function __toString()
@@ -188,7 +187,6 @@ abstract class Enum implements \JsonSerializable
      * Returns all possible values as an array
      *
      * @psalm-pure
-     * @psalm-suppress ImpureStaticProperty
      *
      * @psalm-return array<string, mixed>
      * @return array Constant name in key, constant value in value

--- a/static-analysis/EnumInstantiation.php
+++ b/static-analysis/EnumInstantiation.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyCLabs\Tests\Enum\StaticAnalysis;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @psalm-immutable
+ * @psalm-template T of 'A'|'C'
+ * @template-extends Enum<T>
+ */
+final class InstantiatedEnum extends Enum
+{
+    const A = 'A';
+    const C = 'C';
+}
+
+/**
+ * @psalm-pure
+ * @psalm-return InstantiatedEnum<'A'>
+ */
+function canCallConstructorWithConstantValue(): InstantiatedEnum
+{
+    return new InstantiatedEnum('A');
+}
+
+/**
+ * @psalm-pure
+ * @psalm-return InstantiatedEnum<'C'>
+ */
+function canCallConstructorWithConstantReference(): InstantiatedEnum
+{
+    return new InstantiatedEnum(InstantiatedEnum::C);
+}
+
+/** @psalm-pure */
+function canCallFromWithKnownValue(): InstantiatedEnum
+{
+    return InstantiatedEnum::from('C');
+}
+
+/** @psalm-pure */
+function canCallFromWithUnknownValue(): InstantiatedEnum
+{
+    return InstantiatedEnum::from(123123);
+}

--- a/static-analysis/EnumIsPure.php
+++ b/static-analysis/EnumIsPure.php
@@ -11,7 +11,7 @@ use MyCLabs\Enum\Enum;
  * @method static PureEnum C()
  *
  * @psalm-immutable
- * @psalm-template T of 'A'|'B'
+ * @psalm-template T of 'A'|'C'
  * @template-extends Enum<T>
  */
 final class PureEnum extends Enum

--- a/static-analysis/EnumValidation.php
+++ b/static-analysis/EnumValidation.php
@@ -38,6 +38,18 @@ function canValidateValue($input): string
  * @psalm-pure
  * @param mixed $input
  * @psalm-return 'A'|'C'
+ */
+function canAssertValidEnumValue($input): string
+{
+    ValidationEnum::assertValidEnumValue(ValidationEnum::class, $input);
+
+    return $input;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $input
+ * @psalm-return 'A'|'C'
  *
  * @psalm-suppress MixedReturnStatement
  * @psalm-suppress MixedInferredReturnType at the time of this writing, we did not yet find
@@ -48,6 +60,23 @@ function canValidateValueThroughIsValid($input): string
 {
     if (! ValidationEnum::isValid($input)) {
         throw new \InvalidArgumentException('Value not valid');
+    }
+
+    return $input;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $input
+ * @psalm-return 'A'|'C'|1
+ *
+ * @psalm-suppress InvalidReturnType https://github.com/vimeo/psalm/issues/5372
+ * @psalm-suppress InvalidReturnStatement https://github.com/vimeo/psalm/issues/5372
+ */
+function canValidateValueThroughIsValidEnumValue($input)
+{
+    if (! ValidationEnum::isValidEnumValue(ValidationEnum::class, $input)) {
+        return 1;
     }
 
     return $input;

--- a/static-analysis/EnumValidation.php
+++ b/static-analysis/EnumValidation.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyCLabs\Tests\Enum\StaticAnalysis;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * @psalm-immutable
+ * @psalm-template T of 'A'|'C'
+ * @template-extends Enum<T>
+ */
+final class ValidationEnum extends Enum
+{
+    const A = 'A';
+    const C = 'C';
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $input
+ * @psalm-return 'A'|'C'
+ *
+ * @psalm-suppress MixedReturnStatement
+ * @psalm-suppress MixedInferredReturnType at the time of this writing, we did not yet find
+ *                                         a proper approach to constraint input values through
+ *                                         validation via static methods.
+ */
+function canValidateValue($input): string
+{
+    ValidationEnum::assertValidValue($input);
+
+    return $input;
+}
+
+/**
+ * @psalm-pure
+ * @param mixed $input
+ * @psalm-return 'A'|'C'
+ *
+ * @psalm-suppress MixedReturnStatement
+ * @psalm-suppress MixedInferredReturnType at the time of this writing, we did not yet find
+ *                                         a proper approach to constraint input values through
+ *                                         validation via static methods.
+ */
+function canValidateValueThroughIsValid($input): string
+{
+    if (! ValidationEnum::isValid($input)) {
+        throw new \InvalidArgumentException('Value not valid');
+    }
+
+    return $input;
+}

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -6,6 +6,8 @@
 
 namespace MyCLabs\Tests\Enum;
 
+use MyCLabs\Enum\Enum;
+
 /**
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  * @author Daniel Costa <danielcosta@gmail.com>
@@ -59,12 +61,38 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         EnumFixture::from($value);
     }
 
+    /**
+     * @dataProvider invalidValueProvider
+     * @param mixed $value
+     */
+    public function testRejectInvalidEnumValueWhenAssertingOnIt($value): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('is not part of the enum MyCLabs\Tests\Enum\EnumFixture');
+
+        Enum::assertValidEnumValue(EnumFixture::class, $value);
+    }
+
+    /**
+     * @dataProvider invalidValueProvider
+     * @param mixed $value
+     */
+    public function testReportsFalseOnNonValidEnumValueUponChecking($value): void
+    {
+        self::assertFalse(Enum::isValidEnumValue(EnumFixture::class, $value));
+    }
+
     public function testFailToCreateEnumWithEnumItselfThroughNamedConstructor(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage("Value 'foo' is not part of the enum " . EnumFixture::class);
 
         EnumFixture::from(EnumFixture::FOO());
+    }
+
+    public function testCreateEnumWithValidEnumValueThroughNamedConstructor(): void
+    {
+        self::assertEquals(EnumFixture::FOO(), EnumFixture::from('foo'));
     }
 
     /**
@@ -179,7 +207,8 @@ class EnumTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsValid($value, $isValid)
     {
-        $this->assertSame($isValid, EnumFixture::isValid($value));
+        self::assertSame($isValid, EnumFixture::isValid($value));
+        self::assertSame($isValid, Enum::isValidEnumValue(EnumFixture::class, $value));
     }
 
     public function isValidProvider()
@@ -380,5 +409,20 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         EnumFixture::assertValidValue($value);
 
         self::assertTrue(EnumFixture::isValid($value));
+    }
+
+    /**
+     * @dataProvider isValidProvider
+     */
+    public function testAssertValidValueWithTypedApi($value, $isValid): void
+    {
+        if (!$isValid) {
+            $this->expectException(\UnexpectedValueException::class);
+            $this->expectExceptionMessage("Value '$value' is not part of the enum " . EnumFixture::class);
+        }
+
+        Enum::assertValidEnumValue(EnumFixture::class, $value);
+
+        self::assertTrue(Enum::isValidEnumValue(EnumFixture::class, $value));
     }
 }


### PR DESCRIPTION
This patch introduces two new methods:

* `Enum::isValidEnumValue()`
* `Enum::assertValidEnumValue()`

The `Enum::isValidEnumValue()` is still wonky due to https://github.com/vimeo/psalm/issues/5372, but
overall, this allows for matching against other `Enum` sub-types, by validating that a given `$value`
is effectively a subtype of `T` within an `Enum<T>`.

The previous approach did **not** work, because static method types are not coupled with the class they
are put on (they are effectively namespaced functions, and not much else).


Detailed explanation of what was done is available commit-by-commit, but the idea is that it is impossible to validate `T` for a given `Enum<T>` when a static method is used to do so, because static methods, by definition, are **not** coupled to the class they live on.

Therefore, I had to be a bit more creative: `Enum::assertValidEnumValue(ConcreteEnumClass::class, $value)` is to be used instead.

/cc @michaelpetri @guidobonuzzi @DavideBicego