### PR TITLE
Php8.1 resolve json serializable return datatype deprecation

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -311,6 +311,7 @@ abstract class Enum implements \JsonSerializable
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
      * @psalm-pure
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getValue();

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -311,7 +311,7 @@ abstract class Enum implements \JsonSerializable
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
      * @psalm-pure
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getValue();


### PR DESCRIPTION
Resolution for [Issue #144](https://github.com/myclabs/php-enum/issues/144)

As of PHP 8.1, PHP adds return type declarations to the PHP native functions ___and___ interfaces.

For the `JsonSerializable::jsonSerialize()` interface method, the new signature is:
```php
function jsonSerialize(): mixed {}
```
As this library still supports PHP 7.3, it is not possible to add this return type, as the `mixed` return type only became available in PHP 8.0.

As prior to PHP 8.0, attributes are ignored as if they were comments, it is safe to add the attribute to the library.

To prevent PHPCS tripping up over "something" existing between the function docblock and the declaration, PHPCS 3.6.0 should be used, which is the first PHPCS version with full PHP 8.0 syntax support in the sniffs; but that should be done as a separate PR.

