### PR TITLE
Fix psalm annotation on Enum::from

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -94,8 +94,8 @@ abstract class Enum implements \JsonSerializable
 
     /**
      * @param mixed $value
+     * @psalm-param T $value
      * @return static
-     * @psalm-return static<T>
      */
     public static function from($value): self
     {


### PR DESCRIPTION
* `@return static` is accurate enough, so it doesn't need a clarification for psalm. `static<T>` triggers false-positive alerts from static analyzers and seems to be just a mistake;
* enum entry's template type `T` is more precise as a parameter than `mixed`: it might help catch more errors when using `Enum::from`.