### PR TITLE
Remove psalm template from static method `from`

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -94,7 +94,6 @@ abstract class Enum implements \JsonSerializable
 
     /**
      * @param mixed $value
-     * @psalm-param T $value
      * @return static
      */
     public static function from($value): self


### PR DESCRIPTION
Accoring to vimeo/psalm#2571, psalm doesn't support it
A followup up to #146 (@mnapoli sorry for making you tag another version)