### PR TITLE
Update README.md to explain how to compare enums (singleton limitation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ final class Action extends Enum
 }
 ```
 
+## Comparison
+
+```php
+// returns false
+if ($action === Action::VIEW()) {
+  // ...
+}
+```
+
+```php
+// returns true
+if ($action == Action::VIEW()) {
+  // ...
+}
+
+// true
+if ($action->equals(Action::VIEW())) {
+  // ...
+}
+```
+
+php-enums are not singletons so when doing strict comparison, you are comparing equality of _objects_, not values.
+
 ## Related projects
 
 - [Doctrine enum mapping](https://github.com/acelaya/doctrine-enum-type)


### PR DESCRIPTION
As per my earlier comment https://github.com/myclabs/php-enum/issues/8#issuecomment-877713205, I think it is worthwhile to mention in `README.md` that php-enum are not singletons so when comparing them, strict comparison will not work as expected. @mnapoli Here is the PR as promised. Let me know what you think.