### PR TITLE
Add constants method

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Static methods:
 - `toArray()` method Returns all possible values as an array (constant name in key, constant value in value)
 - `keys()` Returns the names (keys) of all constants in the Enum class
 - `values()` Returns instances of the Enum class of all Enum constants (constant name in key, Enum instance in value)
+- `constants()` Returns raw constant values as an array
 - `isValid()` Check if tested value is valid on enum set
 - `isValidKey()` Check if tested key is valid on enum set
 - `assertValidValue()` Assert the value is valid on enum set, throwing exception otherwise

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -183,6 +183,18 @@ abstract class Enum implements \JsonSerializable
     }
 
     /**
+     * Returns raw constant values as an array
+     *
+     * @psalm-pure
+     * @psalm-return array<int, mixed>
+     * @return array
+     */
+    public static function constants()
+    {
+        return array_values(static::toArray());
+    }
+
+    /**
      * Returns all possible values as an array
      *
      * @psalm-pure

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -136,6 +136,25 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * constants()
+     */
+    public function testConstants()
+    {
+        $constants = EnumFixture::constants();
+        $expectedConstants = array(
+            EnumFixture::FOO,
+            EnumFixture::BAR,
+            EnumFixture::NUMBER,
+            EnumFixture::PROBLEMATIC_NUMBER,
+            EnumFixture::PROBLEMATIC_NULL,
+            EnumFixture::PROBLEMATIC_EMPTY_STRING,
+            EnumFixture::PROBLEMATIC_BOOLEAN_FALSE,
+        );
+
+        $this->assertEquals($expectedConstants, $constants);
+    }
+
+    /**
      * toArray()
      */
     public function testToArray()


### PR DESCRIPTION
I use this awesome enum library in every project, and create this `constants()` method.

For instance, it's useful when you want "only" values of Enum like the following situation with `Rule::in()` in a Laravel project:

```php
'type' => ['required', Rule::in(SomeType::constants())],
```

I was wondering it would be nice if this method is in the base class.



