### PR TITLE
Implement Stringable interface on Enum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     "autoload": {
         "psr-4": {
             "MyCLabs\\Enum\\": "src/"
-        }
+        },
+        "classmap": [
+            "stubs/Stringable.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -19,7 +19,7 @@ namespace MyCLabs\Enum;
  * @psalm-immutable
  * @psalm-consistent-constructor
  */
-abstract class Enum implements \JsonSerializable
+abstract class Enum implements \JsonSerializable, \Stringable
 {
     /**
      * Enum value

--- a/stubs/Stringable.php
+++ b/stubs/Stringable.php
@@ -1,0 +1,11 @@
+<?php
+
+if (\PHP_VERSION_ID < 80000 && !interface_exists('Stringable')) {
+    interface Stringable
+    {
+        /**
+         * @return string
+         */
+        public function __toString();
+    }
+}


### PR DESCRIPTION
Enum class has a `__toString`, so it would be great to implements the new `Stringable` interface.

As the interface is not available for php < 8, I've ~~had the `symfony/polyfill-php-80`~~ implemented a polyfill.