### PR TITLE
Added PHP 8.1 to CI configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         dependencies:
           - "highest"
         include:


### PR DESCRIPTION
**Why?**
PHP 8.1 support now [enumeration in core](https://www.php.net/enumerations). It is good for new project, but when project migrate from < 8.1 to 8.1 is possible a project use this library. This MR check compatible library with last stable PHP version.