### PR TITLE
Declare types of returned data and parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ nbproject/*
 vendor/*
 composer.phar
 composer.lock
+/.php_cs.cache
 /.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ nbproject/*
 vendor/*
 composer.phar
 composer.lock
+/.phpunit.result.cache

--- a/.php-cs-fixer-baseline.json
+++ b/.php-cs-fixer-baseline.json
@@ -1,0 +1,38 @@
+{
+    ".php-cs-fixer-finder.php": {
+        "hash": 2889318273
+    },
+    ".php-cs-fixer.dist.php": {
+        "hash": 3617877428
+    },
+    "bin\/dev\/php-cs-fixer-update-base-line": {
+        "hash": 2767858916
+    },
+    "src\/Enum.php": {
+        "hash": 656222739
+    },
+    "src\/PHPUnit\/Comparator.php": {
+        "hash": 3128575651
+    },
+    "static-analysis\/EnumIsPure.php": {
+        "hash": 2609997503
+    },
+    "stubs\/Stringable.php": {
+        "hash": 3604208188
+    },
+    "tests\/EnumConflict.php": {
+        "hash": 1158864299
+    },
+    "tests\/EnumFixture.php": {
+        "hash": 3647806639
+    },
+    "tests\/EnumTest.php": {
+        "hash": 4104425462
+    },
+    "tests\/InheritedEnumFixture.php": {
+        "hash": 938532675
+    },
+    "tests\/bootstrap.php": {
+        "hash": 19189324
+    }
+}

--- a/.php-cs-fixer-finder.php
+++ b/.php-cs-fixer-finder.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Finder;
+
+return (new Finder())
+    ->in('src')
+    ->in('static-analysis')
+    ->in('stubs')
+    ->in('tests')
+    ->append([
+        'bin/dev/php-cs-fixer-update-base-line',
+        '.php-cs-fixer.dist.php',
+        '.php-cs-fixer-finder.php',
+    ]);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Finder;
+
+$rules = [
+    '@Symfony' => true,
+    '@Symfony:risky' => true,
+    'concat_space' => [
+        'spacing' => 'one',
+    ],
+    'class_definition' => [
+        'single_item_single_line' => true,
+    ],
+    'method_chaining_indentation' => true,
+    'no_superfluous_phpdoc_tags' => true,
+    'phpdoc_align' => false,
+    'phpdoc_annotation_without_dot' => false,
+    'phpdoc_no_alias_tag' => false,
+    'phpdoc_summary' => false,
+    'phpdoc_to_comment' => false,
+    'single_line_throw' => false,
+    'void_return' => true,
+];
+
+function createFinder(): Finder
+{
+    $baseLine = [];
+    $baselinePath = __DIR__ . '/.php-cs-fixer-baseline.json';
+    if (file_exists($baselinePath)) {
+        /** @var array<string,array{ hash: int }> $baseLine */
+        $content = file_get_contents($baselinePath);
+        if (false === $content) {
+            throw new \RuntimeException(sprintf('Cannot get content of baseline file (%s)', $baselinePath));
+        }
+        $baseLine = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+    }
+
+    /** @var Finder $baseFinder */
+    $baseFinder = require __DIR__ . '/.php-cs-fixer-finder.php';
+
+    return (new Finder())->append(excludeNotChangedFiles($baseFinder, $baseLine));
+}
+
+/**
+ * @param array<string,array{ hash: int }> $baseLine
+ *
+ * @return string[]
+ */
+function excludeNotChangedFiles(Finder $finder, array $baseLine): array
+{
+    $paths = [];
+    foreach ($finder as $file) {
+        /** @var \SplFileinfo $file */
+        $filePath = $file->getPathname();
+        $oldHash = $baseLine[$filePath]['hash'] ?? null;
+        $content = file_get_contents($filePath);
+        if (false === $content) {
+            throw new \RuntimeException(sprintf('Cannot get content of file: %s', $filePath));
+        }
+        $newHash = crc32($content ?: '');
+        if ($oldHash !== $newHash) {
+            $paths[] = $filePath;
+        }
+    }
+
+    sort($paths);
+
+    return $paths;
+}
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules($rules)
+    ->setFinder(createFinder())
+    ->setCacheFile(__DIR__ . '/.php_cs.cache');

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,3 +35,11 @@ You can use to fix coding standard if needed:
 ```shell
 composer cs-fix
 ```
+
+Baselines
+---------
+Take into account that "baselines" of checkers added only for:
+- ignoring of existing mistakes on the moment of checkers adding
+- ignoring of known problems but which should not be fixed. 
+
+**Don't update baselines without real reason!** 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+Contributing
+============
+
+Thank you for contributing to this project!
+
+Before we can merge your pull request here are some guidelines that you need to follow.
+These guidelines exist not to annoy you, but to keep the code base clean,
+unified and future proof.
+
+Tests
+-----
+
+Please try to add a test for your pull request.
+
+You can run the tests by calling:
+
+```shell
+composer phpunit
+```
+
+Code quality
+------------
+
+Checking code standard, benchmark, and more.
+
+```shell
+composer code-quality
+```
+
+Coding Standard
+---------------
+
+You can use to fix coding standard if needed:
+
+```shell
+composer cs-fix
+```

--- a/README.md
+++ b/README.md
@@ -192,3 +192,8 @@ Usages and the change needed:
 [Shepherd Image]: https://shepherd.dev/github/myclabs/php-enum/coverage.svg
 
 [Shepherd Link]: https://shepherd.dev/github/myclabs/php-enum
+
+## Contributors
+
+This project exists thanks to [all the people](https://github.com/myclabs/php-enum/graphs/contributors) who contribute. [[Contribute](CONTRIBUTING.md)].
+

--- a/bin/dev/php-cs-fixer-update-base-line
+++ b/bin/dev/php-cs-fixer-update-base-line
@@ -1,0 +1,32 @@
+#!/usr/bin/env php
+<?php
+
+use PhpCsFixer\Finder;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/** @var Finder $finder */
+$finder = require __DIR__ . '/../../.php-cs-fixer-finder.php';
+$baselineFile = __DIR__ . '/../../.php-cs-fixer-baseline.json';
+$files = [];
+
+foreach ($finder as $file) {
+    /** @var \SplFileinfo $file */
+    $filePath = $file->getPathname();
+
+    if (is_dir($filePath)) {
+        continue;
+    }
+
+    $content = file_get_contents($filePath);
+    if (false === $content) {
+        throw new \RuntimeException(sprintf('Cannot get content of file: %s', $filePath));
+    }
+    $files[$filePath] = [
+        'hash' => crc32($content),
+    ];
+}
+
+ksort($files);
+file_put_contents($baselineFile, json_encode($files, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT));
+echo sprintf("Ok, %s files added to baseline\n", count($files));

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,19 @@
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "1.*",
         "vimeo/psalm": "^4.6.2"
+    },
+    "scripts": {
+        "code-quality": [
+            "@composer install --ansi",
+            "@phpstan-analyse",
+            "@cs-check",
+            "@phpstan-check",
+            "@psalm-check"
+        ],
+        "cs-fix": "vendor/bin/php-cs-fixer fix -vv",
+        "cs-check": "vendor/bin/php-cs-fixer fix -vv --dry-run",
+        "phpstan-check": "vendor/bin/phpstan analyse",
+        "phpunit": "vendor/bin/phpunit",
+        "psalm-check": "vendor/bin/psalm"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,15 @@
             "MyCLabs\\Tests\\Enum\\": "tests/"
         }
     },
+    "config": {
+        "sort-packages": true
+    },
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {
+        "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "1.*",
         "vimeo/psalm": "^4.6.2"

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "ext-json": "*"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.4",
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "1.*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,266 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to static method MyCLabs\\\\Enum\\\\Enum\\<mixed\\>\\:\\:assertValidValueReturningKey\\(\\) on a separate line has no effect\\.$#"
+			count: 1
+			path: src/Enum.php
+
+		-
+			message: "#^Method MyCLabs\\\\Enum\\\\Enum\\:\\:__callStatic\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Enum.php
+
+		-
+			message: "#^PHPDoc tag @var above assignment does not specify variable name\\.$#"
+			count: 1
+			path: src/Enum.php
+
+		-
+			message: "#^Property MyCLabs\\\\Enum\\\\Enum\\<T\\>\\:\\:\\$key \\(string\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: src/Enum.php
+
+		-
+			message: "#^Unsafe call to private method MyCLabs\\\\Enum\\\\Enum\\<T\\>\\:\\:assertValidValueReturningKey\\(\\) through static\\:\\:\\.$#"
+			count: 2
+			path: src/Enum.php
+
+		-
+			message: "#^Method MyCLabs\\\\Enum\\\\PHPUnit\\\\Comparator\\:\\:assertEquals\\(\\) has parameter \\$actual with generic class MyCLabs\\\\Enum\\\\Enum but does not specify its types\\: T$#"
+			count: 1
+			path: src/PHPUnit/Comparator.php
+
+		-
+			message: "#^Method MyCLabs\\\\Enum\\\\PHPUnit\\\\Comparator\\:\\:assertEquals\\(\\) has parameter \\$expected with generic class MyCLabs\\\\Enum\\\\Enum but does not specify its types\\: T$#"
+			count: 1
+			path: src/PHPUnit/Comparator.php
+
+		-
+			message: "#^Method MyCLabs\\\\Enum\\\\PHPUnit\\\\Comparator\\:\\:formatEnum\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/PHPUnit/Comparator.php
+
+		-
+			message: "#^Method MyCLabs\\\\Enum\\\\PHPUnit\\\\Comparator\\:\\:formatEnum\\(\\) has parameter \\$enum with generic class MyCLabs\\\\Enum\\\\Enum but does not specify its types\\: T$#"
+			count: 1
+			path: src/PHPUnit/Comparator.php
+
+		-
+			message: "#^Function MyCLabs\\\\Tests\\\\Enum\\\\StaticAnalysis\\\\enumFetchViaExplicitMagicCallIsPure\\(\\) return type with generic class MyCLabs\\\\Tests\\\\Enum\\\\StaticAnalysis\\\\PureEnum does not specify its types\\: T$#"
+			count: 1
+			path: static-analysis/EnumIsPure.php
+
+		-
+			message: "#^Function MyCLabs\\\\Tests\\\\Enum\\\\StaticAnalysis\\\\enumFetchViaMagicMethodIsPure\\(\\) return type with generic class MyCLabs\\\\Tests\\\\Enum\\\\StaticAnalysis\\\\PureEnum does not specify its types\\: T$#"
+			count: 1
+			path: static-analysis/EnumIsPure.php
+
+		-
+			message: "#^Class MyCLabs\\\\Tests\\\\Enum\\\\EnumConflict extends generic class MyCLabs\\\\Enum\\\\Enum but does not specify its types\\: T$#"
+			count: 1
+			path: tests/EnumConflict.php
+
+		-
+			message: "#^Class MyCLabs\\\\Tests\\\\Enum\\\\EnumFixture extends generic class MyCLabs\\\\Enum\\\\Enum but does not specify its types\\: T$#"
+			count: 1
+			path: tests/EnumFixture.php
+
+		-
+			message: "#^Call to an undefined static method MyCLabs\\\\Tests\\\\Enum\\\\EnumFixture\\:\\:UNKNOWN\\(\\)\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:assertJsonEqualsJson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:assertJsonEqualsJson\\(\\) has parameter \\$json1 with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:assertJsonEqualsJson\\(\\) has parameter \\$json2 with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:invalidValueProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:isValidProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:searchProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testAssertValidValue\\(\\) has parameter \\$isValid with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testAssertValidValue\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testBadStaticAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testBooleanEnum\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testConstructWithSameEnumArgument\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testCreatingEnumWithInvalidValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testCreatingEnumWithInvalidValue\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testEnumValuesInheritance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testEquals\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testEqualsComparesProblematicValuesProperly\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testEqualsConflictValues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testGetKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testGetValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testIsValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testIsValid\\(\\) has parameter \\$isValid with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testIsValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testIsValidKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testJsonSerialize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testKeys\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testNullableEnum\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testSearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testSearch\\(\\) has parameter \\$expected with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testSearch\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testSerialize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testStaticAccess\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testToArray\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testToString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testToString\\(\\) has parameter \\$enumObject with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testToString\\(\\) has parameter \\$expected with no type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testUnserialize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testUnserializeVersionWithoutKey\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:testValues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php
+
+		-
+			message: "#^Method MyCLabs\\\\Tests\\\\Enum\\\\EnumTest\\:\\:toStringProvider\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/EnumTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,9 @@ parameters:
         - static-analysis
         - stubs
         - tests
+        - bin/dev/php-cs-fixer-update-base-line
+        - .php-cs-fixer.dist.php
+        - .php-cs-fixer-finder.php
 
     parallel:
         processTimeout: 300.0

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,15 @@
+includes:
+	- phpstan-baseline.neon
+
+parameters:
+    level: 7
+    reportUnmatchedIgnoredErrors: false
+
+    paths:
+        - src
+        - static-analysis
+        - stubs
+        - tests
+
+    parallel:
+        processTimeout: 300.0

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.26.0@6998fabb2bf528b65777bf9941920888d23c03ac">
+  <file src="src/Enum.php">
+    <UnsafeGenericInstantiation occurrences="2">
+      <code>new static($array[$name])</code>
+      <code>new static($value)</code>
+    </UnsafeGenericInstantiation>
+    <UnusedPsalmSuppress occurrences="2">
+      <code>ImpureStaticProperty</code>
+      <code>InvalidCast</code>
+    </UnusedPsalmSuppress>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,9 +5,11 @@
       <code>new static($array[$name])</code>
       <code>new static($value)</code>
     </UnsafeGenericInstantiation>
-    <UnusedPsalmSuppress occurrences="2">
+    <UnusedPsalmSuppress occurrences="4">
       <code>ImpureStaticProperty</code>
-      <code>InvalidCast</code>
+      <code>ImpureVariable</code>
+      <code>ImpureVariable</code>
+      <code>ImpureVariable</code>
     </UnusedPsalmSuppress>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
-    resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+    findUnusedPsalmSuppress="true"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @link    http://github.com/myclabs/php-enum
+ *
  * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
  */
 
@@ -24,7 +25,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
     /**
      * Enum value
      *
-     * @var mixed
+     * @var mixed|null
      * @psalm-var T
      */
     protected $value;
@@ -38,7 +39,6 @@ abstract class Enum implements \JsonSerializable, \Stringable
 
     /**
      * Store existing constants in a static cache per object.
-     *
      *
      * @var array<class-string, array<string, static>>
      * @psalm-var array<class-string, array<string, mixed>>
@@ -57,9 +57,11 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * Creates a new value of some type
      *
      * @psalm-pure
-     * @param mixed $value
+     *
+     * @param mixed|null $value
      *
      * @psalm-param T $value
+     *
      * @throws \UnexpectedValueException if incompatible type is given.
      */
     public function __construct($value)
@@ -99,10 +101,10 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * This method exists only for the compatibility reason when deserializing a previously serialized version
      * that didn't have the key property
      */
-    public function __wakeup()
+    public function __wakeup(): void
     {
         /** @psalm-suppress DocblockTypeContradiction key can be null when deserializing an enum without the key */
-        if ($this->key === null) {
+        if (null === $this->key) {
             /**
              * @psalm-suppress InaccessibleProperty key is not readonly as marked by psalm
              */
@@ -111,7 +113,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
     }
 
     /**
-     * @param mixed $value
+     * @param mixed|null $value
      *
      * @return static
      */
@@ -124,7 +126,8 @@ abstract class Enum implements \JsonSerializable, \Stringable
 
     /**
      * @psalm-pure
-     * @return mixed
+     *
+     * @return mixed|null
      * @psalm-return T
      */
     #[\ReturnTypeWillChange]
@@ -175,11 +178,12 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @psalm-pure
      * @psalm-return list<string>
+     *
      * @return array<string>
      */
     public static function keys(): array
     {
-        return \array_keys(static::toArray());
+        return array_keys(static::toArray());
     }
 
     /**
@@ -187,6 +191,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @psalm-pure
      * @psalm-return array<string, static>
+     *
      * @return static[] Constant name in key, Enum instance in value
      */
     public static function values(): array
@@ -208,6 +213,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * @psalm-suppress ImpureStaticProperty
      *
      * @psalm-return array<string, mixed>
+     *
      * @return array<string, mixed> Constant name in key, constant value in value
      */
     public static function toArray(): array
@@ -216,7 +222,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
 
         if (!isset(static::$cache[$class])) {
             /** @psalm-suppress ImpureMethodCall this reflection API usage has no side-effects here */
-            $reflection            = new \ReflectionClass($class);
+            $reflection = new \ReflectionClass($class);
             /** @psalm-suppress ImpureMethodCall this reflection API usage has no side-effects here */
             static::$cache[$class] = $reflection->getConstants();
         }
@@ -227,7 +233,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
     /**
      * Check if is valid enum value
      *
-     * @param mixed $value
+     * @param mixed|null $value
      *
      * @psalm-param mixed $value
      * @psalm-pure
@@ -244,7 +250,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * @psalm-pure
      * @psalm-assert T $value
      *
-     * @param mixed $value
+     * @param mixed|null $value
      */
     public static function assertValidValue($value): void
     {
@@ -257,7 +263,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * @psalm-pure
      * @psalm-assert T $value
      *
-     * @param mixed $value
+     * @param mixed|null $value
      */
     protected static function assertValidValueReturningKey($value): string
     {
@@ -284,14 +290,14 @@ abstract class Enum implements \JsonSerializable, \Stringable
     /**
      * Return key for value
      *
-     * @param mixed $value
+     * @param mixed|null $value
      *
      * @psalm-param mixed $value
      * @psalm-pure
      */
     public static function search($value): ?string
     {
-        $index = \array_search($value, static::toArray(), true);
+        $index = array_search($value, static::toArray(), true);
 
         return false === $index ? null : $index;
     }
@@ -300,9 +306,10 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * Returns a value when called statically like so: MyEnum::SOME_VALUE() given SOME_VALUE is a class constant
      *
      * @param string $name
-     * @param array  $arguments
+     * @param array<int,mixed> $arguments
      *
      * @return static
+     *
      * @throws \BadMethodCallException
      *
      * @psalm-pure
@@ -327,7 +334,8 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * Specify data which should be serialized to JSON. This method returns data that can be serialized by json_encode()
      * natively.
      *
-     * @return mixed
+     * @return mixed|null
+     *
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
      * @psalm-pure
      */

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -101,7 +101,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
     {
         $key = static::assertValidValueReturningKey($value);
 
-        return self::__callStatic($key, []);
+        return static::__callStatic($key, []);
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -69,7 +69,6 @@ abstract class Enum implements \JsonSerializable, \Stringable
             $value = $value->getValue();
         }
 
-        /** @psalm-suppress ImplicitToStringCast assertValidValueReturningKey returns always a string but psalm has currently an issue here */
         $this->key = static::assertValidValueReturningKey($value);
 
         /** @psalm-var T $value */
@@ -106,7 +105,6 @@ abstract class Enum implements \JsonSerializable, \Stringable
         if ($this->key === null) {
             /**
              * @psalm-suppress InaccessibleProperty key is not readonly as marked by psalm
-             * @psalm-suppress PossiblyFalsePropertyAssignmentValue deserializing a case that was removed
              */
             $this->key = static::assertValidValueReturningKey($this->value);
         }
@@ -132,6 +130,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
     #[\ReturnTypeWillChange]
     public function getValue()
     {
+        /** @psalm-suppress ImpureVariable */
         return $this->value;
     }
 
@@ -142,15 +141,16 @@ abstract class Enum implements \JsonSerializable, \Stringable
      */
     public function getKey(): string
     {
+        /** @psalm-suppress ImpureVariable */
         return $this->key;
     }
 
     /**
      * @psalm-pure
-     * @psalm-suppress InvalidCast
      */
     public function __toString(): string
     {
+        /** @psalm-suppress ImpureVariable */
         return (string) $this->value;
     }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -241,7 +241,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      */
     private static function assertValidValueReturningKey($value): string
     {
-        if (false === ($key = static::search($value))) {
+        if (null === ($key = static::search($value))) {
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);
         }
 
@@ -268,11 +268,12 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @psalm-param mixed $value
      * @psalm-pure
-     * @return string|false
      */
-    public static function search($value)
+    public static function search($value): ?string
     {
-        return \array_search($value, static::toArray(), true);
+        $index = \array_search($value, static::toArray(), true);
+
+        return false === $index ? null : $index;
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -108,7 +108,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
              * @psalm-suppress InaccessibleProperty key is not readonly as marked by psalm
              * @psalm-suppress PossiblyFalsePropertyAssignmentValue deserializing a case that was removed
              */
-            $this->key = static::search($this->value);
+            $this->key = static::assertValidValueReturningKey($this->value);
         }
     }
 
@@ -248,7 +248,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      */
     public static function assertValidValue($value): void
     {
-        self::assertValidValueReturningKey($value);
+        static::assertValidValueReturningKey($value);
     }
 
     /**
@@ -259,7 +259,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @param mixed $value
      */
-    private static function assertValidValueReturningKey($value): string
+    protected static function assertValidValueReturningKey($value): string
     {
         if (null === ($key = static::search($value))) {
             throw new \UnexpectedValueException("Value '$value' is not part of the enum " . static::class);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -40,7 +40,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * Store existing constants in a static cache per object.
      *
      *
-     * @var array
+     * @var array<class-string, array<string, static>>
      * @psalm-var array<class-string, array<string, mixed>>
      */
     protected static $cache = [];
@@ -48,7 +48,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
     /**
      * Cache of instances of the Enum class
      *
-     * @var array
+     * @var array<class-string, array<string, static>>
      * @psalm-var array<class-string, array<string, static>>
      */
     protected static $instances = [];
@@ -65,20 +65,20 @@ abstract class Enum implements \JsonSerializable, \Stringable
     public function __construct($value)
     {
         if ($value instanceof static) {
-           /** @psalm-var T */
+            /** @psalm-var T $value */
             $value = $value->getValue();
         }
 
         /** @psalm-suppress ImplicitToStringCast assertValidValueReturningKey returns always a string but psalm has currently an issue here */
         $this->key = static::assertValidValueReturningKey($value);
 
-        /** @psalm-var T */
+        /** @psalm-var T $value */
         $this->value = $value;
     }
 
     /**
      * This method exists only for the compatibility reason when deserializing a previously serialized version
-     * that didn't had the key property
+     * that didn't have the key property
      */
     public function __wakeup()
     {
@@ -94,6 +94,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
 
     /**
      * @param mixed $value
+     *
      * @return static
      */
     public static function from($value): self
@@ -108,6 +109,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * @return mixed
      * @psalm-return T
      */
+    #[\ReturnTypeWillChange]
     public function getValue()
     {
         return $this->value;
@@ -117,9 +119,8 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * Returns the enum key (i.e. the constant name).
      *
      * @psalm-pure
-     * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -127,11 +128,10 @@ abstract class Enum implements \JsonSerializable, \Stringable
     /**
      * @psalm-pure
      * @psalm-suppress InvalidCast
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
-        return (string)$this->value;
+        return (string) $this->value;
     }
 
     /**
@@ -142,7 +142,6 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @psalm-pure
      * @psalm-param mixed $variable
-     * @return bool
      */
     final public function equals($variable = null): bool
     {
@@ -156,9 +155,9 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @psalm-pure
      * @psalm-return list<string>
-     * @return array
+     * @return array<string>
      */
-    public static function keys()
+    public static function keys(): array
     {
         return \array_keys(static::toArray());
     }
@@ -170,9 +169,9 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * @psalm-return array<string, static>
      * @return static[] Constant name in key, Enum instance in value
      */
-    public static function values()
+    public static function values(): array
     {
-        $values = array();
+        $values = [];
 
         /** @psalm-var T $value */
         foreach (static::toArray() as $key => $value) {
@@ -189,9 +188,9 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * @psalm-suppress ImpureStaticProperty
      *
      * @psalm-return array<string, mixed>
-     * @return array Constant name in key, constant value in value
+     * @return array<string, mixed> Constant name in key, constant value in value
      */
-    public static function toArray()
+    public static function toArray(): array
     {
         $class = static::class;
 
@@ -208,13 +207,13 @@ abstract class Enum implements \JsonSerializable, \Stringable
     /**
      * Check if is valid enum value
      *
-     * @param $value
+     * @param mixed $value
+     *
      * @psalm-param mixed $value
      * @psalm-pure
      * @psalm-assert-if-true T $value
-     * @return bool
      */
-    public static function isValid($value)
+    public static function isValid($value): bool
     {
         return \in_array($value, static::toArray(), true);
     }
@@ -224,6 +223,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @psalm-pure
      * @psalm-assert T $value
+     *
      * @param mixed $value
      */
     public static function assertValidValue($value): void
@@ -236,8 +236,8 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @psalm-pure
      * @psalm-assert T $value
+     *
      * @param mixed $value
-     * @return string
      */
     private static function assertValidValueReturningKey($value): string
     {
@@ -251,12 +251,10 @@ abstract class Enum implements \JsonSerializable, \Stringable
     /**
      * Check if is valid enum key
      *
-     * @param $key
      * @psalm-param string $key
      * @psalm-pure
-     * @return bool
      */
-    public static function isValidKey($key)
+    public static function isValidKey(string $key): bool
     {
         $array = static::toArray();
 
@@ -297,8 +295,10 @@ abstract class Enum implements \JsonSerializable, \Stringable
                 $message = "No static method or enum constant '$name' in class " . static::class;
                 throw new \BadMethodCallException($message);
             }
+
             return self::$instances[$class][$name] = new static($array[$name]);
         }
+
         return clone self::$instances[$class][$name];
     }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -34,7 +34,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @var string
      */
-    private $key;
+    protected $key;
 
     /**
      * Store existing constants in a static cache per object.
@@ -74,6 +74,26 @@ abstract class Enum implements \JsonSerializable, \Stringable
 
         /** @psalm-var T $value */
         $this->value = $value;
+    }
+
+    /**
+     * This method exists only for the compatibility reason when deserializing a previously serialized version
+     * that didn't have the key property
+     *
+     * @param array<string,mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $zeroChar = \chr(0);
+        foreach ($data as $key => $value) {
+            if (false !== strpos($key, $zeroChar)) {
+                $parts = explode($zeroChar, $key);
+                $key = $parts[array_key_last($parts)];
+            }
+            $this->{$key} = $value;
+        }
+
+        $this->__wakeup();
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -289,17 +289,17 @@ abstract class Enum implements \JsonSerializable, \Stringable
     public static function __callStatic($name, $arguments)
     {
         $class = static::class;
-        if (!isset(self::$instances[$class][$name])) {
+        if (!isset(static::$instances[$class][$name])) {
             $array = static::toArray();
             if (!isset($array[$name]) && !\array_key_exists($name, $array)) {
                 $message = "No static method or enum constant '$name' in class " . static::class;
                 throw new \BadMethodCallException($message);
             }
 
-            return self::$instances[$class][$name] = new static($array[$name]);
+            return static::$instances[$class][$name] = new static($array[$name]);
         }
 
-        return clone self::$instances[$class][$name];
+        return clone static::$instances[$class][$name];
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -1,22 +1,25 @@
 <?php
 /**
  * @link    http://github.com/myclabs/php-enum
+ *
  * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
  */
 
 namespace MyCLabs\Tests\Enum;
+
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  * @author Daniel Costa <danielcosta@gmail.com>
  * @author Mirosław Filip <mirfilip@gmail.com>
  */
-class EnumTest extends \PHPUnit\Framework\TestCase
+class EnumTest extends TestCase
 {
     /**
      * getValue()
      */
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $value = new EnumFixture(EnumFixture::FOO);
         $this->assertEquals(EnumFixture::FOO, $value->getValue());
@@ -31,15 +34,17 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     /**
      * getKey()
      */
-    public function testGetKey()
+    public function testGetKey(): void
     {
         $value = new EnumFixture(EnumFixture::FOO);
         $this->assertEquals('FOO', $value->getKey());
         $this->assertNotEquals('BA', $value->getKey());
     }
 
-    /** @dataProvider invalidValueProvider */
-    public function testCreatingEnumWithInvalidValue($value)
+    /**
+     * @dataProvider invalidValueProvider
+     */
+    public function testCreatingEnumWithInvalidValue($value): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('is not part of the enum ' . EnumFixture::class);
@@ -49,7 +54,8 @@ class EnumTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider invalidValueProvider
-     * @param mixed $value
+     *
+     * @param mixed|null $value
      */
     public function testFailToCreateEnumWithInvalidValueThroughNamedConstructor($value): void
     {
@@ -69,49 +75,54 @@ class EnumTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Contains values not existing in EnumFixture
-     * @return array
+     *
+     * @return array<string,array<string|int>>
      */
-    public function invalidValueProvider()
+    public function invalidValueProvider(): iterable
     {
-        return array(
-            "string" => array('test'),
-            "int" => array(1234),
-        );
+        return [
+            'string' => ['test'],
+            'int' => [1234],
+        ];
     }
 
     /**
      * __toString()
+     *
      * @dataProvider toStringProvider
      */
-    public function testToString($expected, $enumObject)
+    public function testToString(string $expected, EnumFixture $enumObject): void
     {
         $this->assertSame($expected, (string) $enumObject);
     }
 
-    public function toStringProvider()
+    /**
+     * @return iterable<array{0: string, 1: EnumFixture}>
+     */
+    public function toStringProvider(): iterable
     {
-        return array(
-            array(EnumFixture::FOO, new EnumFixture(EnumFixture::FOO)),
-            array(EnumFixture::BAR, new EnumFixture(EnumFixture::BAR)),
-            array((string) EnumFixture::NUMBER, new EnumFixture(EnumFixture::NUMBER)),
-        );
+        return [
+            [EnumFixture::FOO, new EnumFixture(EnumFixture::FOO)],
+            [EnumFixture::BAR, new EnumFixture(EnumFixture::BAR)],
+            [(string) EnumFixture::NUMBER, new EnumFixture(EnumFixture::NUMBER)],
+        ];
     }
 
     /**
      * keys()
      */
-    public function testKeys()
+    public function testKeys(): void
     {
         $values = EnumFixture::keys();
-        $expectedValues = array(
-            "FOO",
-            "BAR",
-            "NUMBER",
-            "PROBLEMATIC_NUMBER",
-            "PROBLEMATIC_NULL",
-            "PROBLEMATIC_EMPTY_STRING",
-            "PROBLEMATIC_BOOLEAN_FALSE",
-        );
+        $expectedValues = [
+            'FOO',
+            'BAR',
+            'NUMBER',
+            'PROBLEMATIC_NUMBER',
+            'PROBLEMATIC_NULL',
+            'PROBLEMATIC_EMPTY_STRING',
+            'PROBLEMATIC_BOOLEAN_FALSE',
+        ];
 
         $this->assertSame($expectedValues, $values);
     }
@@ -119,18 +130,18 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     /**
      * values()
      */
-    public function testValues()
+    public function testValues(): void
     {
         $values = EnumFixture::values();
-        $expectedValues = array(
-            "FOO"                       => new EnumFixture(EnumFixture::FOO),
-            "BAR"                       => new EnumFixture(EnumFixture::BAR),
-            "NUMBER"                    => new EnumFixture(EnumFixture::NUMBER),
-            "PROBLEMATIC_NUMBER"        => new EnumFixture(EnumFixture::PROBLEMATIC_NUMBER),
-            "PROBLEMATIC_NULL"          => new EnumFixture(EnumFixture::PROBLEMATIC_NULL),
-            "PROBLEMATIC_EMPTY_STRING"  => new EnumFixture(EnumFixture::PROBLEMATIC_EMPTY_STRING),
-            "PROBLEMATIC_BOOLEAN_FALSE" => new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE),
-        );
+        $expectedValues = [
+            'FOO' => new EnumFixture(EnumFixture::FOO),
+            'BAR' => new EnumFixture(EnumFixture::BAR),
+            'NUMBER' => new EnumFixture(EnumFixture::NUMBER),
+            'PROBLEMATIC_NUMBER' => new EnumFixture(EnumFixture::PROBLEMATIC_NUMBER),
+            'PROBLEMATIC_NULL' => new EnumFixture(EnumFixture::PROBLEMATIC_NULL),
+            'PROBLEMATIC_EMPTY_STRING' => new EnumFixture(EnumFixture::PROBLEMATIC_EMPTY_STRING),
+            'PROBLEMATIC_BOOLEAN_FALSE' => new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE),
+        ];
 
         $this->assertEquals($expectedValues, $values);
     }
@@ -138,18 +149,18 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     /**
      * toArray()
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $values = EnumFixture::toArray();
-        $expectedValues = array(
-            "FOO"                   => EnumFixture::FOO,
-            "BAR"                   => EnumFixture::BAR,
-            "NUMBER"                => EnumFixture::NUMBER,
-            "PROBLEMATIC_NUMBER"    => EnumFixture::PROBLEMATIC_NUMBER,
-            "PROBLEMATIC_NULL"      => EnumFixture::PROBLEMATIC_NULL,
-            "PROBLEMATIC_EMPTY_STRING"    => EnumFixture::PROBLEMATIC_EMPTY_STRING,
-            "PROBLEMATIC_BOOLEAN_FALSE"    => EnumFixture::PROBLEMATIC_BOOLEAN_FALSE,
-        );
+        $expectedValues = [
+            'FOO' => EnumFixture::FOO,
+            'BAR' => EnumFixture::BAR,
+            'NUMBER' => EnumFixture::NUMBER,
+            'PROBLEMATIC_NUMBER' => EnumFixture::PROBLEMATIC_NUMBER,
+            'PROBLEMATIC_NULL' => EnumFixture::PROBLEMATIC_NULL,
+            'PROBLEMATIC_EMPTY_STRING' => EnumFixture::PROBLEMATIC_EMPTY_STRING,
+            'PROBLEMATIC_BOOLEAN_FALSE' => EnumFixture::PROBLEMATIC_BOOLEAN_FALSE,
+        ];
 
         $this->assertSame($expectedValues, $values);
     }
@@ -157,7 +168,7 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     /**
      * __callStatic()
      */
-    public function testStaticAccess()
+    public function testStaticAccess(): void
     {
         $this->assertEquals(new EnumFixture(EnumFixture::FOO), EnumFixture::FOO());
         $this->assertEquals(new EnumFixture(EnumFixture::BAR), EnumFixture::BAR());
@@ -165,7 +176,7 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertNotSame(EnumFixture::NUMBER(), EnumFixture::NUMBER());
     }
 
-    public function testBadStaticAccess()
+    public function testBadStaticAccess(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('No static method or enum constant \'UNKNOWN\' in class ' . EnumFixture::class);
@@ -175,14 +186,20 @@ class EnumTest extends \PHPUnit\Framework\TestCase
 
     /**
      * isValid()
+     *
+     * @param int|string|bool|null $value
+     *
      * @dataProvider isValidProvider
      */
-    public function testIsValid($value, $isValid)
+    public function testIsValid($value, bool $isValid): void
     {
         $this->assertSame($isValid, EnumFixture::isValid($value));
     }
 
-    public function isValidProvider()
+    /**
+     * @return iterable<array<int,mixed>>
+     */
+    public function isValidProvider(): iterable
     {
         return [
             /**
@@ -197,14 +214,14 @@ class EnumTest extends \PHPUnit\Framework\TestCase
             /**
              * Invalid values
              */
-            ['baz', false]
+            ['baz', false],
         ];
     }
 
     /**
      * isValidKey()
      */
-    public function testIsValidKey()
+    public function testIsValidKey(): void
     {
         $this->assertTrue(EnumFixture::isValidKey('FOO'));
         $this->assertFalse(EnumFixture::isValidKey('BAZ'));
@@ -213,31 +230,37 @@ class EnumTest extends \PHPUnit\Framework\TestCase
 
     /**
      * search()
+     *
      * @see https://github.com/myclabs/php-enum/issues/13
      * @dataProvider searchProvider
+     *
+     * @param mixed|null $value
      */
-    public function testSearch($value, $expected)
+    public function testSearch($value, ?string $expected): void
     {
         $this->assertSame($expected, EnumFixture::search($value));
     }
 
-    public function searchProvider()
+    /**
+     * @return iterable<array<int,mixed>>
+     */
+    public function searchProvider(): iterable
     {
-        return array(
-            array('foo', 'FOO'),
-            array(0, 'PROBLEMATIC_NUMBER'),
-            array(null, 'PROBLEMATIC_NULL'),
-            array('', 'PROBLEMATIC_EMPTY_STRING'),
-            array(false, 'PROBLEMATIC_BOOLEAN_FALSE'),
-            array('bar I do not exist', null),
-            array(array(), null),
-        );
+        return [
+            ['foo', 'FOO'],
+            [0, 'PROBLEMATIC_NUMBER'],
+            [null, 'PROBLEMATIC_NULL'],
+            ['', 'PROBLEMATIC_EMPTY_STRING'],
+            [false, 'PROBLEMATIC_BOOLEAN_FALSE'],
+            ['bar I do not exist', null],
+            [[], null],
+        ];
     }
 
     /**
      * equals()
      */
-    public function testEquals()
+    public function testEquals(): void
     {
         $foo = new EnumFixture(EnumFixture::FOO);
         $number = new EnumFixture(EnumFixture::NUMBER);
@@ -256,7 +279,7 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     /**
      * equals()
      */
-    public function testEqualsComparesProblematicValuesProperly()
+    public function testEqualsComparesProblematicValuesProperly(): void
     {
         $false = new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE);
         $emptyString = new EnumFixture(EnumFixture::PROBLEMATIC_EMPTY_STRING);
@@ -271,7 +294,7 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     /**
      * equals()
      */
-    public function testEqualsConflictValues()
+    public function testEqualsConflictValues(): void
     {
         $this->assertFalse(EnumFixture::FOO()->equals(EnumConflict::FOO()));
     }
@@ -279,31 +302,31 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     /**
      * jsonSerialize()
      */
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
-        $this->assertJsonEqualsJson('"foo"', json_encode(new EnumFixture(EnumFixture::FOO)));
-        $this->assertJsonEqualsJson('"bar"', json_encode(new EnumFixture(EnumFixture::BAR)));
-        $this->assertJsonEqualsJson('42', json_encode(new EnumFixture(EnumFixture::NUMBER)));
-        $this->assertJsonEqualsJson('0', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_NUMBER)));
-        $this->assertJsonEqualsJson('null', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_NULL)));
-        $this->assertJsonEqualsJson('""', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_EMPTY_STRING)));
-        $this->assertJsonEqualsJson('false', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE)));
+        $this->assertJsonEqualsJson('"foo"', json_encode(new EnumFixture(EnumFixture::FOO), \JSON_THROW_ON_ERROR));
+        $this->assertJsonEqualsJson('"bar"', json_encode(new EnumFixture(EnumFixture::BAR), \JSON_THROW_ON_ERROR));
+        $this->assertJsonEqualsJson('42', json_encode(new EnumFixture(EnumFixture::NUMBER), \JSON_THROW_ON_ERROR));
+        $this->assertJsonEqualsJson('0', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_NUMBER), \JSON_THROW_ON_ERROR));
+        $this->assertJsonEqualsJson('null', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_NULL), \JSON_THROW_ON_ERROR));
+        $this->assertJsonEqualsJson('""', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_EMPTY_STRING), \JSON_THROW_ON_ERROR));
+        $this->assertJsonEqualsJson('false', json_encode(new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE), \JSON_THROW_ON_ERROR));
     }
 
-    public function testNullableEnum()
+    public function testNullableEnum(): void
     {
         $this->assertNull(EnumFixture::PROBLEMATIC_NULL()->getValue());
         $this->assertNull((new EnumFixture(EnumFixture::PROBLEMATIC_NULL))->getValue());
         $this->assertNull((new EnumFixture(EnumFixture::PROBLEMATIC_NULL))->jsonSerialize());
     }
 
-    public function testBooleanEnum()
+    public function testBooleanEnum(): void
     {
         $this->assertFalse(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE()->getValue());
         $this->assertFalse((new EnumFixture(EnumFixture::PROBLEMATIC_BOOLEAN_FALSE))->jsonSerialize());
     }
 
-    public function testConstructWithSameEnumArgument()
+    public function testConstructWithSameEnumArgument(): void
     {
         $enum = new EnumFixture(EnumFixture::FOO);
 
@@ -312,24 +335,24 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($enum, $enveloped);
     }
 
-    private function assertJsonEqualsJson($json1, $json2)
+    private function assertJsonEqualsJson(string $json1, string $json2): void
     {
         $this->assertJsonStringEqualsJsonString($json1, $json2);
     }
 
-    public function testSerialize()
+    public function testSerialize(): void
     {
         // split string for Pretty CI: "Line exceeds 120 characters"
         $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d46697874757265223a323a7b733a383a'
-            .'22002a0076616c7565223b733a333a22666f6f223b733a363a22002a006b6579223b733a333a22464f4f223b7d';
+            . '22002a0076616c7565223b733a333a22666f6f223b733a363a22002a006b6579223b733a333a22464f4f223b7d';
 
         $this->assertEquals($bin, bin2hex(serialize(EnumFixture::FOO())));
     }
 
-    public function testUnserializeVersionWithoutKey()
+    public function testUnserializeVersionWithoutKey(): void
     {
         // split string for Pretty CI: "Line exceeds 120 characters"
-        $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787'.
+        $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787' .
             '4757265223a313a7b733a383a22002a0076616c7565223b733a333a22666f6f223b7d';
 
         /* @var $value EnumFixture */
@@ -340,11 +363,11 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(EnumFixture::FOO() == $value);
     }
 
-    public function testUnserializeOld()
+    public function testUnserializeOld(): void
     {
         // split string for Pretty CI: "Line exceeds 120 characters"
-        $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787'.
-            '4757265223a323a7b733a383a22002a0076616c7565223b733a333a22666f6f223b73'.
+        $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787' .
+            '4757265223a323a7b733a383a22002a0076616c7565223b733a333a22666f6f223b73' .
             '3a32323a22004d79434c6162735c456e756d5c456e756d006b6579223b733a333a22464f4f223b7d';
 
         /* @var $value EnumFixture */
@@ -355,11 +378,11 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(EnumFixture::FOO() == $value);
     }
 
-    public function testUnserialize()
+    public function testUnserialize(): void
     {
         // split string for Pretty CI: "Line exceeds 120 characters"
         $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d46697874757265223a323a7b733a383a'
-            .'22002a0076616c7565223b733a333a22666f6f223b733a363a22002a006b6579223b733a333a22464f4f223b7d';
+            . '22002a0076616c7565223b733a333a22666f6f223b733a363a22002a006b6579223b733a333a22464f4f223b7d';
 
         /* @var $value EnumFixture */
         $value = unserialize(pack('H*', $bin));
@@ -372,7 +395,7 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     /**
      * @see https://github.com/myclabs/php-enum/issues/95
      */
-    public function testEnumValuesInheritance()
+    public function testEnumValuesInheritance(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage("Value 'value' is not part of the enum MyCLabs\Tests\Enum\EnumFixture");
@@ -381,9 +404,11 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @param int|string|bool|mixed|null $value
+     *
      * @dataProvider isValidProvider
      */
-    public function testAssertValidValue($value, $isValid): void
+    public function testAssertValidValue($value, bool $isValid): void
     {
         if (!$isValid) {
             $this->expectException(\UnexpectedValueException::class);

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -229,8 +229,8 @@ class EnumTest extends \PHPUnit\Framework\TestCase
             array(null, 'PROBLEMATIC_NULL'),
             array('', 'PROBLEMATIC_EMPTY_STRING'),
             array(false, 'PROBLEMATIC_BOOLEAN_FALSE'),
-            array('bar I do not exist', false),
-            array(array(), false),
+            array('bar I do not exist', null),
+            array(array(), null),
         );
     }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -320,9 +320,8 @@ class EnumTest extends \PHPUnit\Framework\TestCase
     public function testSerialize()
     {
         // split string for Pretty CI: "Line exceeds 120 characters"
-        $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787'.
-            '4757265223a323a7b733a383a22002a0076616c7565223b733a333a22666f6f223b73'.
-            '3a32323a22004d79434c6162735c456e756d5c456e756d006b6579223b733a333a22464f4f223b7d';
+        $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d46697874757265223a323a7b733a383a'
+            .'22002a0076616c7565223b733a333a22666f6f223b733a363a22002a006b6579223b733a333a22464f4f223b7d';
 
         $this->assertEquals($bin, bin2hex(serialize(EnumFixture::FOO())));
     }
@@ -341,12 +340,26 @@ class EnumTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(EnumFixture::FOO() == $value);
     }
 
-    public function testUnserialize()
+    public function testUnserializeOld()
     {
         // split string for Pretty CI: "Line exceeds 120 characters"
         $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d4669787'.
             '4757265223a323a7b733a383a22002a0076616c7565223b733a333a22666f6f223b73'.
             '3a32323a22004d79434c6162735c456e756d5c456e756d006b6579223b733a333a22464f4f223b7d';
+
+        /* @var $value EnumFixture */
+        $value = unserialize(pack('H*', $bin));
+
+        $this->assertEquals(EnumFixture::FOO, $value->getValue());
+        $this->assertTrue(EnumFixture::FOO()->equals($value));
+        $this->assertTrue(EnumFixture::FOO() == $value);
+    }
+
+    public function testUnserialize()
+    {
+        // split string for Pretty CI: "Line exceeds 120 characters"
+        $bin = '4f3a33303a224d79434c6162735c54657374735c456e756d5c456e756d46697874757265223a323a7b733a383a'
+            .'22002a0076616c7565223b733a333a22666f6f223b733a363a22002a006b6579223b733a333a22464f4f223b7d';
 
         /* @var $value EnumFixture */
         $value = unserialize(pack('H*', $bin));


### PR DESCRIPTION
Backward compatibility breaks:

- Declared types of parameters and returned data.
- Method `\MyCLabs\Enum\Enum::search()` returns only `string` or `null`. It could return `false` when the value is not found. It returns `null` in this case now.
- Property `\MyCLabs\Enum\Enum::$key` became protected. So, serialized value changed. Nonetheless old serialized values will be unserialized correctly.
- Private method `\MyCLabs\Enum\Enum::assertValidValueReturningKey()` became protected.
- Changed calls from `self::...` to `static::...`.
- Changed access to static property from `self::...` to `static::...`.