### PR TITLE
Fix isValid static analysis

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -209,9 +209,8 @@ abstract class Enum implements \JsonSerializable, \Stringable
      * Check if is valid enum value
      *
      * @param $value
-     * @psalm-param mixed $value
+     * @psalm-param T $value
      * @psalm-pure
-     * @psalm-assert-if-true T $value
      * @return bool
      */
     public static function isValid($value)


### PR DESCRIPTION
I don't think the `@psalm-assert-if-true` is correct here. It causes false-positives like this with PHPStan 1.9:

```
Call to static method MyCLabs\Enum\Enum<string>::isValid() with string will always evaluate to true.
```

Which is of course wrong. Even if value is a string it doesn't necessarily mean it's one of the valid values for the enum.

Instead I think we should type $value with T since it doesn't really make sense to call isValid with a different type anyway - that would always return false.

cc @michaelpetri 