### PR TITLE
Upgrade to Psalm 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "1.*",
-        "vimeo/psalm": "^4.6.2"
+        "vimeo/psalm": "^5.2"
     }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -176,6 +176,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
 
         /** @psalm-var T $value */
         foreach (static::toArray() as $key => $value) {
+            /** @psalm-suppress UnsafeGenericInstantiation */
             $values[$key] = new static($value);
         }
 
@@ -297,6 +298,7 @@ abstract class Enum implements \JsonSerializable, \Stringable
                 $message = "No static method or enum constant '$name' in class " . static::class;
                 throw new \BadMethodCallException($message);
             }
+            /** @psalm-suppress UnsafeGenericInstantiation */
             return self::$instances[$class][$name] = new static($array[$name]);
         }
         return clone self::$instances[$class][$name];
@@ -308,7 +310,6 @@ abstract class Enum implements \JsonSerializable, \Stringable
      *
      * @return mixed
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @psalm-pure
      */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()


### PR DESCRIPTION
Hi,

When upgrading to Psalm 5, there are some errors that have appeared:

```
ERROR: UnsafeGenericInstantiation - src/Enum.php:179:29 - Cannot safely instantiate generic class MyCLabs\Enum\Enum with "new static" as its generic parameters may be constrained in child classes. (see https://psalm.dev/269)
            $values[$key] = new static($value);


ERROR: UnsafeGenericInstantiation - src/Enum.php:300:54 - Cannot safely instantiate generic class MyCLabs\Enum\Enum with "new static" as its generic parameters may be constrained in child classes. (see https://psalm.dev/269)
            return self::$instances[$class][$name] = new static($array[$name]);


ERROR: ImpureMethodCall - src/Enum.php:313:7 - Cannot call an impure constructor from a pure context (see https://psalm.dev/203)
    #[\ReturnTypeWillChange]
```

I have silenced them as a first approach. We can fix them on this PR or create another one once this is one is merged.

