### PR TITLE
PHP 8.2 CI Support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         dependencies:
           - "highest"
         include:


### PR DESCRIPTION
Hi,

This PR adds PHP 8.2 to the CI versions matrix.