### PR TITLE
fix php8.4 deprecated

### DIFF
--- a/src/PHPUnit/Comparator.php
+++ b/src/PHPUnit/Comparator.php
@@ -43,7 +43,7 @@ final class Comparator extends \SebastianBergmann\Comparator\Comparator
         );
     }
 
-    private function formatEnum(Enum $enum = null)
+    private function formatEnum(?Enum $enum = null)
     {
         if ($enum === null) {
             return "null";


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  MyCLabs\Enum\PHPUnit\Comparator::formatEnum(): Implicitly marking parameter $enum as nullable is deprecated, the explicit nullable type must be used instead in ./myclabs/php-enum/src/PHPUnit/Comparator.php on line 46
```